### PR TITLE
chore: update all dependencies

### DIFF
--- a/Jellyfin.Plugin.FiletreeCleaner.Tests/Jellyfin.Plugin.FiletreeCleaner.Tests.csproj
+++ b/Jellyfin.Plugin.FiletreeCleaner.Tests/Jellyfin.Plugin.FiletreeCleaner.Tests.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.9.11" />
-    <PackageReference Include="Jellyfin.Model" Version="10.9.11" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.8" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Jellyfin.Plugin.FiletreeCleaner/Jellyfin.Plugin.FiletreeCleaner.csproj
+++ b/Jellyfin.Plugin.FiletreeCleaner/Jellyfin.Plugin.FiletreeCleaner.csproj
@@ -18,10 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.9.11" >
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.8" >
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Jellyfin.Model" Version="10.9.11">
+    <PackageReference Include="Jellyfin.Model" Version="10.11.8">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/Jellyfin.Plugin.FiletreeCleaner/ScheduledTasks/CleanEmptyMediaFoldersTask.cs
+++ b/Jellyfin.Plugin.FiletreeCleaner/ScheduledTasks/CleanEmptyMediaFoldersTask.cs
@@ -226,7 +226,7 @@ public class CleanEmptyMediaFoldersTask : IScheduledTask
         [
             new TaskTriggerInfo
             {
-                Type = TaskTriggerInfo.TriggerWeekly,
+                Type = TaskTriggerInfoType.WeeklyTrigger,
                 DayOfWeek = DayOfWeek.Sunday,
                 TimeOfDayTicks = TimeSpan.FromHours(3).Ticks
             }

--- a/Jellyfin.Plugin.FiletreeCleaner/ScheduledTasks/CleanTrickplayTask.cs
+++ b/Jellyfin.Plugin.FiletreeCleaner/ScheduledTasks/CleanTrickplayTask.cs
@@ -185,7 +185,7 @@ public class CleanTrickplayTask : IScheduledTask
         [
             new TaskTriggerInfo
             {
-                Type = TaskTriggerInfo.TriggerWeekly,
+                Type = TaskTriggerInfoType.WeeklyTrigger,
                 DayOfWeek = DayOfWeek.Sunday,
                 TimeOfDayTicks = TimeSpan.FromHours(2).Ticks
             }


### PR DESCRIPTION
```javascript
chore: update all NuGet dependencies & fix Jellyfin 10.11.x breaking change
```

__PR Body:__

```markdown
## Summary

Consolidates all open Dependabot PRs (#5–#10) into a single dependency update and fixes a breaking API change introduced in Jellyfin 10.11.x.

## NuGet Package Updates

| Package | Old | New |
|---|---|---|
| `Jellyfin.Controller` | 10.9.11 | 10.11.8 |
| `Jellyfin.Model` | 10.9.11 | 10.11.8 |
| `Microsoft.NET.Test.Sdk` | 17.11.1 | 18.4.0 |
| `xunit` | 2.9.2 | 2.9.3 |
| `xunit.runner.visualstudio` | 2.8.2 | 3.1.5 |
| `coverlet.collector` | 6.0.2 | 8.0.1 |

## Breaking Change Fix

Jellyfin 10.11.x replaced the `TaskTriggerInfo.TriggerWeekly` string constant with the `TaskTriggerInfoType.WeeklyTrigger` enum value. Both `CleanTrickplayTask` and `CleanEmptyMediaFoldersTask` have been updated accordingly.

## Verification

- ✅ `dotnet build` — 0 warnings, 0 errors
- ✅ `dotnet test` — 49/49 tests passed

Closes #5, closes #6, closes #7, closes #8, closes #9, closes #10
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to compatible versions
  * Updated scheduled task trigger configuration format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->