### PR TITLE
fix: only include manifest.json and build.yaml in metadata PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,4 +160,7 @@ jobs:
 
           This PR was created automatically by the release workflow.
         branch: chore/update-metadata-${{ env.VERSION }}
+        add-paths: |
+          manifest.json
+          build.yaml
         delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,4 @@ jobs:
 
           This PR was created automatically by the release workflow.
         branch: chore/update-metadata-${{ env.VERSION }}
-        add-paths: |
-          manifest.json
-          build.yaml
         delete-branch: true

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "versions": [
       {
         "version": "1.0.1",
-        "changelog": "Initial release. Trickplay folder cleanup, empty media folder cleanup, dry-run modes for both.",
+        "changelog": "Trickplay folder cleanup, empty media folder cleanup, dry-run modes for both.",
         "targetAbi": "10.11.0.0",
         "sourceUrl": "https://github.com/JellyPlugins/jellyfin-cleaner/releases/download/1.0.1/FiletreeCleaner_1.0.1.zip",
         "checksum": "placeholder",

--- a/manifest.json
+++ b/manifest.json
@@ -8,10 +8,10 @@
     "category": "General",
     "versions": [
       {
-        "version": "1.0.0",
+        "version": "1.0.1",
         "changelog": "Initial release. Trickplay folder cleanup, empty media folder cleanup, dry-run modes for both.",
         "targetAbi": "10.11.0.0",
-        "sourceUrl": "https://github.com/JellyPlugins/jellyfin-cleaner/releases/download/1.0.0/FiletreeCleaner_1.0.0.zip",
+        "sourceUrl": "https://github.com/JellyPlugins/jellyfin-cleaner/releases/download/1.0.1/FiletreeCleaner_1.0.1.zip",
         "checksum": "placeholder",
         "timestamp": "2026-04-09T00:00:00Z"
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped plugin release to v1.0.1 and updated the download link for the new archive.
  * Revised changelog wording (removed “Initial release” phrasing); no functional changes to the plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->