### PR TITLE
fix: trash dialog is showing, fix some IDE findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] — 2026-04-11
+
+### Fixed
+- **Trash exclusion in statistics** — Trash folders are now explicitly excluded from media statistics calculations to avoid distorted results.
+- **TV show metadata false positives** — Fixed a bug where empty metadata directories of TV shows were incorrectly marked as orphaned.
+- **Trash dialog in UI** — Fix for the confirmation dialog when disabling the trash, which was not showing under certain conditions.
+
+---
+
 ## [1.0.5] — 2026-11-04
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.0.4.0</Version>
-        <AssemblyVersion>1.0.4.0</AssemblyVersion>
-        <FileVersion>1.0.4.0</FileVersion>
+        <Version>1.0.6.0</Version>
+        <AssemblyVersion>1.0.6.0</AssemblyVersion>
+        <FileVersion>1.0.6.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Api/MediaStatisticsControllerTrashTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Api/MediaStatisticsControllerTrashTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Jellyfin.Plugin.JellyfinHelper.Tests.Api;
 
+[Collection("ConfigOverride")]
 public class MediaStatisticsControllerTrashTests : IDisposable
 {
     private readonly MediaStatisticsController _controller;

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Api/MediaStatisticsControllerTrashTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Api/MediaStatisticsControllerTrashTests.cs
@@ -1,0 +1,248 @@
+﻿using Jellyfin.Plugin.JellyfinHelper.Api;
+using Jellyfin.Plugin.JellyfinHelper.Configuration;
+using Jellyfin.Plugin.JellyfinHelper.Services;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.IO;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Api;
+
+public class MediaStatisticsControllerTrashTests : IDisposable
+{
+    private readonly MediaStatisticsController _controller;
+    private readonly Mock<ILibraryManager> _libraryManagerMock;
+    private readonly string _tempPath;
+
+    public MediaStatisticsControllerTrashTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), "JellyfinHelperTests_" + Guid.NewGuid());
+        Directory.CreateDirectory(_tempPath);
+
+        _libraryManagerMock = new Mock<ILibraryManager>();
+        _libraryManagerMock.Setup(m => m.GetVirtualFolders()).Returns(new List<VirtualFolderInfo>());
+
+        var fileSystemMock = new Mock<IFileSystem>();
+        var appPathsMock = new Mock<IApplicationPaths>();
+        appPathsMock.Setup(p => p.DataPath).Returns(_tempPath);
+        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var loggerMock = new Mock<ILogger<MediaStatisticsController>>();
+        var serviceLoggerMock = new Mock<ILogger<MediaStatisticsService>>();
+        var historyLoggerMock = new Mock<ILogger<StatisticsHistoryService>>();
+
+        _controller = new MediaStatisticsController(
+            _libraryManagerMock.Object,
+            fileSystemMock.Object,
+            appPathsMock.Object,
+            httpClientFactoryMock.Object,
+            cache,
+            loggerMock.Object,
+            serviceLoggerMock.Object,
+            historyLoggerMock.Object);
+            
+        CleanupConfigHelper.ConfigOverride = new PluginConfiguration();
+    }
+
+    public void Dispose()
+    {
+        CleanupConfigHelper.ConfigOverride = null;
+        if (Directory.Exists(_tempPath))
+        {
+            Directory.Delete(_tempPath, true);
+        }
+    }
+
+    private void SetupLibraries(params string[] paths)
+    {
+        var folders = new List<VirtualFolderInfo>();
+        foreach (var path in paths)
+        {
+            var folder = new VirtualFolderInfo
+            {
+                Name = Path.GetFileName(path),
+                Locations = new[] { path },
+                CollectionType = CollectionTypeOptions.movies
+            };
+            folders.Add(folder);
+        }
+        _libraryManagerMock.Setup(m => m.GetVirtualFolders()).Returns(folders);
+    }
+
+    [Fact]
+    public void GetTrashFolders_AbsoluteTrashPath_ReturnsExistingPath()
+    {
+        var trashPath = Path.Combine(_tempPath, "GlobalTrash");
+        Directory.CreateDirectory(trashPath);
+        
+        CleanupConfigHelper.ConfigOverride = new PluginConfiguration
+        {
+            TrashFolderPath = trashPath
+        };
+
+        var result = _controller.GetTrashFolders();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        dynamic data = okResult.Value!;
+        Assert.True(data.IsAbsolute);
+        var paths = Assert.IsType<List<string>>(data.Paths);
+        Assert.Single(paths);
+        Assert.Equal(trashPath, paths[0]);
+    }
+
+    [Fact]
+    public void GetTrashFolders_AbsoluteTrashPath_ReturnsEmptyIfNotExist()
+    {
+        var trashPath = Path.Combine(_tempPath, "NonExistentTrash");
+        
+        CleanupConfigHelper.ConfigOverride = new PluginConfiguration
+        {
+            TrashFolderPath = trashPath
+        };
+
+        var result = _controller.GetTrashFolders();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        dynamic data = okResult.Value!;
+        Assert.True(data.IsAbsolute);
+        var paths = Assert.IsType<List<string>>(data.Paths);
+        Assert.Empty(paths);
+    }
+
+    [Fact]
+    public void GetTrashFolders_RelativeTrashPath_ReturnsExistingLibraryTrash()
+    {
+        var lib1 = Path.Combine(_tempPath, "Movies");
+        var lib2 = Path.Combine(_tempPath, "TV");
+        Directory.CreateDirectory(lib1);
+        Directory.CreateDirectory(lib2);
+        
+        var trash1 = Path.Combine(lib1, ".jellyfin-trash");
+        Directory.CreateDirectory(trash1);
+        
+        SetupLibraries(lib1, lib2);
+        
+        CleanupConfigHelper.ConfigOverride = new PluginConfiguration
+        {
+            TrashFolderPath = ".jellyfin-trash"
+        };
+
+        var result = _controller.GetTrashFolders();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        dynamic data = okResult.Value!;
+        Assert.False(data.IsAbsolute);
+        var paths = Assert.IsType<List<string>>(data.Paths);
+        Assert.Single(paths);
+        Assert.Equal(trash1, paths[0]);
+    }
+
+    [Fact]
+    public void GetTrashFolders_RelativeTrashPath_ReturnsMultipleFolders()
+    {
+        var lib1 = Path.Combine(_tempPath, "Movies");
+        var lib2 = Path.Combine(_tempPath, "TV");
+        Directory.CreateDirectory(lib1);
+        Directory.CreateDirectory(lib2);
+        
+        var trash1 = Path.Combine(lib1, ".jellyfin-trash");
+        var trash2 = Path.Combine(lib2, ".jellyfin-trash");
+        Directory.CreateDirectory(trash1);
+        Directory.CreateDirectory(trash2);
+        
+        SetupLibraries(lib1, lib2);
+        
+        CleanupConfigHelper.ConfigOverride = new PluginConfiguration
+        {
+            TrashFolderPath = ".jellyfin-trash"
+        };
+
+        var result = _controller.GetTrashFolders();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        dynamic data = okResult.Value!;
+        Assert.False(data.IsAbsolute);
+        var paths = Assert.IsType<List<string>>(data.Paths);
+        Assert.Equal(2, paths.Count);
+        Assert.Contains(trash1, paths);
+        Assert.Contains(trash2, paths);
+    }
+
+    [Fact]
+    public void DeleteTrashFolders_AbsoluteTrashPath_DeletesFolder()
+    {
+        var trashPath = Path.Combine(_tempPath, "GlobalTrash");
+        Directory.CreateDirectory(trashPath);
+        File.WriteAllText(Path.Combine(trashPath, "test.txt"), "content");
+        
+        CleanupConfigHelper.ConfigOverride = new PluginConfiguration
+        {
+            TrashFolderPath = trashPath
+        };
+
+        var result = _controller.DeleteTrashFolders();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        dynamic data = okResult.Value!;
+        var deleted = Assert.IsType<List<string>>(data.Deleted);
+        Assert.Single(deleted);
+        Assert.Equal(Path.GetFullPath(trashPath), Path.GetFullPath(deleted[0]));
+        Assert.False(Directory.Exists(trashPath));
+    }
+
+    [Fact]
+    public void DeleteTrashFolders_RelativeTrashPath_DeletesMultipleFolders()
+    {
+        var lib1 = Path.Combine(_tempPath, "Movies");
+        var lib2 = Path.Combine(_tempPath, "TV");
+        Directory.CreateDirectory(lib1);
+        Directory.CreateDirectory(lib2);
+        
+        var trash1 = Path.Combine(lib1, ".jellyfin-trash");
+        var trash2 = Path.Combine(lib2, ".jellyfin-trash");
+        Directory.CreateDirectory(trash1);
+        Directory.CreateDirectory(trash2);
+        
+        SetupLibraries(lib1, lib2);
+        
+        CleanupConfigHelper.ConfigOverride = new PluginConfiguration
+        {
+            TrashFolderPath = ".jellyfin-trash"
+        };
+
+        var result = _controller.DeleteTrashFolders();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        dynamic data = okResult.Value!;
+        var deleted = Assert.IsType<List<string>>(data.Deleted);
+        Assert.Equal(2, deleted.Count);
+        Assert.False(Directory.Exists(trash1));
+        Assert.False(Directory.Exists(trash2));
+    }
+
+    [Fact]
+    public void DeleteTrashFolders_UnsafePath_ReturnsBadRequest()
+    {
+        var lib1 = Path.Combine(_tempPath, "Movies");
+        Directory.CreateDirectory(lib1);
+        
+        SetupLibraries(lib1);
+        
+        CleanupConfigHelper.ConfigOverride = new PluginConfiguration
+        {
+            TrashFolderPath = lib1
+        };
+
+        var result = _controller.DeleteTrashFolders();
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        dynamic data = badRequest.Value!;
+        Assert.Contains("unsafe", (string)data.Error);
+        Assert.True(Directory.Exists(lib1));
+    }
+}

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/ArrIntegrationHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/ArrIntegrationHtmlTests.cs
@@ -1,6 +1,6 @@
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.PluginPages;
 
 public class ArrIntegrationHtmlTests : ConfigPageTestBase
 {

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/CodecsHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/CodecsHtmlTests.cs
@@ -1,6 +1,6 @@
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.PluginPages;
 
 /// <summary>
 /// Tests for the Codecs tab in the composed configPage.html.

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/ConfigPageHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/ConfigPageHtmlTests.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.PluginPages;
 
 /// <summary>
 /// General page structure and README quality tests.

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/ConfigPageTestBase.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/ConfigPageTestBase.cs
@@ -1,6 +1,6 @@
 using Jellyfin.Plugin.JellyfinHelper.Configuration;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.PluginPages;
 
 /// <summary>
 /// Shared base class for all configPage.html tests.

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/HealthHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/HealthHtmlTests.cs
@@ -1,6 +1,6 @@
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.PluginPages;
 
 public class HealthHtmlTests : ConfigPageTestBase
 {

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/OverviewHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/OverviewHtmlTests.cs
@@ -1,6 +1,6 @@
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.PluginPages;
 
 /// <summary>
 /// Tests for the Overview tab in the composed configPage.html.

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/SettingsHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/SettingsHtmlTests.cs
@@ -1,10 +1,9 @@
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.JellyfinHelper.Configuration;
-using Jellyfin.Plugin.JellyfinHelper.ScheduledTasks;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.PluginPages;
 
 public class SettingsHtmlTests : ConfigPageTestBase
 {
@@ -131,9 +130,7 @@ public class SettingsHtmlTests : ConfigPageTestBase
     public void Html_TrashDisableDialog_CallsGetTrashFoldersEndpoint()
     {
         Assert.Matches(
-            new System.Text.RegularExpressions.Regex(
-                @"type\s*:\s*['""]GET['""].*JellyfinHelper/Trash/Folders",
-                System.Text.RegularExpressions.RegexOptions.Singleline),
+            new Regex(@"type\s*:\s*['""]GET['""].*JellyfinHelper/Trash/Folders", RegexOptions.Singleline),
             HtmlContent);
     }
 

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/TrendsHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/TrendsHtmlTests.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 using Jellyfin.Plugin.JellyfinHelper.Services;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.PluginPages;
 
 public class TrendsHtmlTests : ConfigPageTestBase
 {

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/ScheduledTasks/CleanEmptyMediaFoldersTaskTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/ScheduledTasks/CleanEmptyMediaFoldersTaskTests.cs
@@ -8,7 +8,7 @@ using Moq;
 using Xunit;
 using MediaBrowser.Model.Entities;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.ScheduledTasks;
 
 [Collection("ConfigOverride")]
 public class CleanEmptyMediaFoldersTaskTests : IDisposable

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/ScheduledTasks/CleanOrphanedSubtitlesTaskTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/ScheduledTasks/CleanOrphanedSubtitlesTaskTests.cs
@@ -1,7 +1,7 @@
 using Jellyfin.Plugin.JellyfinHelper.ScheduledTasks;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.ScheduledTasks;
 
 /// <summary>
 /// Tests for <see cref="CleanOrphanedSubtitlesTask"/> subtitle name parsing logic.

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/ScheduledTasks/CleanTrickplayTaskTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/ScheduledTasks/CleanTrickplayTaskTests.cs
@@ -8,7 +8,7 @@ using Moq;
 using Xunit;
 using MediaBrowser.Model.Entities;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.ScheduledTasks;
 
 [Collection("ConfigOverride")]
 public class CleanTrickplayTaskTests : IDisposable

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/ScheduledTasks/HelperCleanupTaskTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/ScheduledTasks/HelperCleanupTaskTests.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.ScheduledTasks;
 
 /// <summary>
 /// Tests for <see cref="HelperCleanupTask"/>, the master orchestration task.

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/ScheduledTasks/RepairStrmFilesTaskTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/ScheduledTasks/RepairStrmFilesTaskTests.cs
@@ -5,7 +5,7 @@ using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
 using Moq;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.ScheduledTasks;
 
 /// <summary>
 /// Tests for <see cref="RepairStrmFilesTask"/>.

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/ArrComparisonResultTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/ArrComparisonResultTests.cs
@@ -1,7 +1,7 @@
 using Jellyfin.Plugin.JellyfinHelper.Services;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services;
 
 public class ArrComparisonResultTests
 {

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/ArrIntegrationServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/ArrIntegrationServiceTests.cs
@@ -9,7 +9,7 @@ using Moq;
 using Moq.Protected;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services;
 
 public class ArrIntegrationServiceTests
 {

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/CleanupConfigHelperTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/CleanupConfigHelperTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Jellyfin.Plugin.JellyfinHelper.Services;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services;
 
 [Collection("ConfigOverride")]
 public class CleanupConfigHelperTests

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/I18nServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/I18nServiceTests.cs
@@ -5,7 +5,7 @@ using Jellyfin.Plugin.JellyfinHelper.Configuration;
 using Jellyfin.Plugin.JellyfinHelper.Services;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services;
 
 public class I18nServiceTests
 {

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/MediaStatisticsServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/MediaStatisticsServiceTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services;
 
 public class MediaStatisticsServiceTests
 {

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/MediaStatisticsServiceTvShowTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/MediaStatisticsServiceTvShowTests.cs
@@ -1,0 +1,232 @@
+﻿using Jellyfin.Plugin.JellyfinHelper.Services;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services
+{
+    public class MediaStatisticsServiceTvShowTests
+    {
+        private readonly Mock<ILibraryManager> _libraryManagerMock;
+        private readonly Mock<IFileSystem> _fileSystemMock;
+        private readonly MediaStatisticsService _service;
+
+        public MediaStatisticsServiceTvShowTests()
+        {
+            _libraryManagerMock = new Mock<ILibraryManager>();
+            _fileSystemMock = new Mock<IFileSystem>();
+            var loggerMock = new Mock<ILogger<MediaStatisticsService>>();
+            _service = new MediaStatisticsService(_libraryManagerMock.Object, _fileSystemMock.Object, loggerMock.Object);
+        }
+
+        private string TestPath(params string[] segments) => string.Join(Path.DirectorySeparatorChar.ToString(), segments);
+
+        [Fact]
+        public void CalculateStatistics_TvShowStructure_Series1AndSpecials_ShouldNotBeOrphaned()
+        {
+            // root
+            //  └─ Series 1 (metadata here: folder.jpg, series.nfo)
+            //      ├─ Season 01
+            //      │   └─ S01E01.mkv
+            //      └─ Specials
+            //          └─ S00E01.mkv
+
+            var libraryPath = TestPath("media", "tv");
+            var seriesPath = TestPath("media", "tv", "Series 1");
+            var season01Path = TestPath("media", "tv", "Series 1", "Season 01");
+            var specialsPath = TestPath("media", "tv", "Series 1", "Specials");
+
+            var virtualFolder = new VirtualFolderInfo
+            {
+                Name = "TV Shows",
+                CollectionType = CollectionTypeOptions.tvshows,
+                Locations = new[] { libraryPath }
+            };
+            _libraryManagerMock.Setup(m => m.GetVirtualFolders()).Returns(new List<VirtualFolderInfo> { virtualFolder });
+
+            // Root
+            _fileSystemMock.Setup(f => f.GetFiles(libraryPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+            _fileSystemMock.Setup(f => f.GetDirectories(libraryPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = seriesPath, Name = "Series 1", IsDirectory = true }
+            });
+
+            // Series 1 - Contains metadata but no direct video files
+            _fileSystemMock.Setup(f => f.GetFiles(seriesPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = TestPath(seriesPath, "folder.jpg"), Name = "folder.jpg", Length = 100_000, IsDirectory = false },
+                new FileSystemMetadata { FullName = TestPath(seriesPath, "tvshow.nfo"), Name = "tvshow.nfo", Length = 5_000, IsDirectory = false }
+            });
+            _fileSystemMock.Setup(f => f.GetDirectories(seriesPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = season01Path, Name = "Season 01", IsDirectory = true },
+                new FileSystemMetadata { FullName = specialsPath, Name = "Specials", IsDirectory = true }
+            });
+
+            // Season 01 - Contains video
+            _fileSystemMock.Setup(f => f.GetFiles(season01Path, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = TestPath(season01Path, "S01E01.mkv"), Name = "S01E01.mkv", Length = 1_000_000_000, IsDirectory = false }
+            });
+            _fileSystemMock.Setup(f => f.GetDirectories(season01Path, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+
+            // Specials - Contains video
+            _fileSystemMock.Setup(f => f.GetFiles(specialsPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = TestPath(specialsPath, "S00E01.mkv"), Name = "S00E01.mkv", Length = 500_000_000, IsDirectory = false }
+            });
+            _fileSystemMock.Setup(f => f.GetDirectories(specialsPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+
+            var result = _service.CalculateStatistics();
+            var stats = result.Libraries[0];
+
+            Assert.DoesNotContain(seriesPath, stats.OrphanedMetadataDirectoriesPaths);
+            Assert.Equal(0, stats.OrphanedMetadataDirectories);
+        }
+
+        [Fact]
+        public void CalculateStatistics_TrulyOrphanedDir_ShouldStillBeDetected()
+        {
+            var libraryPath = TestPath("media", "tv");
+            var orphanPath = TestPath("media", "tv", "OrphanedFolder");
+
+            var virtualFolder = new VirtualFolderInfo
+            {
+                Name = "TV Shows",
+                CollectionType = CollectionTypeOptions.tvshows,
+                Locations = new[] { libraryPath }
+            };
+            _libraryManagerMock.Setup(m => m.GetVirtualFolders()).Returns(new List<VirtualFolderInfo> { virtualFolder });
+
+            _fileSystemMock.Setup(f => f.GetFiles(libraryPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+            _fileSystemMock.Setup(f => f.GetDirectories(libraryPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = orphanPath, Name = "OrphanedFolder", IsDirectory = true }
+            });
+
+            // OrphanedFolder - metadata but no videos AND no subdirectories containing videos
+            _fileSystemMock.Setup(f => f.GetFiles(orphanPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = TestPath(orphanPath, "random.srt"), Name = "random.srt", Length = 50_000, IsDirectory = false }
+            });
+            _fileSystemMock.Setup(f => f.GetDirectories(orphanPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+
+            var result = _service.CalculateStatistics();
+            var stats = result.Libraries[0];
+
+            Assert.Contains(orphanPath, stats.OrphanedMetadataDirectoriesPaths);
+            Assert.Equal(1, stats.OrphanedMetadataDirectories);
+        }
+
+        [Fact]
+        public void CalculateStatistics_EmptyFolder_ShouldNotBeOrphaned()
+        {
+            var libraryPath = TestPath("media", "tv");
+            var emptyPath = TestPath("media", "tv", "EmptyFolder");
+
+            var virtualFolder = new VirtualFolderInfo
+            {
+                Name = "TV Shows",
+                CollectionType = CollectionTypeOptions.tvshows,
+                Locations = new[] { libraryPath }
+            };
+            _libraryManagerMock.Setup(m => m.GetVirtualFolders()).Returns(new List<VirtualFolderInfo> { virtualFolder });
+
+            _fileSystemMock.Setup(f => f.GetFiles(libraryPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+            _fileSystemMock.Setup(f => f.GetDirectories(libraryPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = emptyPath, Name = "EmptyFolder", IsDirectory = true }
+            });
+
+            // EmptyFolder - no files, no subdirs
+            _fileSystemMock.Setup(f => f.GetFiles(emptyPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+            _fileSystemMock.Setup(f => f.GetDirectories(emptyPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+
+            var result = _service.CalculateStatistics();
+            var stats = result.Libraries[0];
+
+            Assert.Empty(stats.OrphanedMetadataDirectoriesPaths);
+            Assert.Equal(0, stats.OrphanedMetadataDirectories);
+        }
+
+        [Fact]
+        public void CalculateStatistics_SpecialsWithoutEpisodes_ShouldNotBeOrphanedIfMetadataExists()
+        {
+            // Specials folder often contains its own metadata (images) even if no episodes are currently there
+            // Actually, if it has metadata but no episodes, it might be seen as orphaned by current logic.
+            // But if it's named "Specials" or "Season 00", it should probably be ignored in TV libraries.
+
+            var libraryPath = TestPath("media", "tv");
+            var seriesPath = TestPath("media", "tv", "Series 1");
+            var specialsPath = TestPath("media", "tv", "Series 1", "Specials");
+
+            var virtualFolder = new VirtualFolderInfo
+            {
+                Name = "TV Shows",
+                CollectionType = CollectionTypeOptions.tvshows,
+                Locations = new[] { libraryPath }
+            };
+            _libraryManagerMock.Setup(m => m.GetVirtualFolders()).Returns(new List<VirtualFolderInfo> { virtualFolder });
+
+            _fileSystemMock.Setup(f => f.GetFiles(libraryPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+            _fileSystemMock.Setup(f => f.GetDirectories(libraryPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = seriesPath, Name = "Series 1", IsDirectory = true }
+            });
+
+            _fileSystemMock.Setup(f => f.GetFiles(seriesPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+            _fileSystemMock.Setup(f => f.GetDirectories(seriesPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = specialsPath, Name = "Specials", IsDirectory = true }
+            });
+
+            // Specials folder with only an image
+            _fileSystemMock.Setup(f => f.GetFiles(specialsPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = TestPath(specialsPath, "season-specials-poster.jpg"), Name = "season-specials-poster.jpg", Length = 50_000, IsDirectory = false }
+            });
+            _fileSystemMock.Setup(f => f.GetDirectories(specialsPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+
+            var result = _service.CalculateStatistics();
+            var stats = result.Libraries[0];
+
+            // Currently, 'Specials' would be reported as orphaned.
+            Assert.DoesNotContain(specialsPath, stats.OrphanedMetadataDirectoriesPaths);
+        }
+
+        [Fact]
+        public void CalculateStatistics_MovieLibrary_StillDetectsOrphanedDirs()
+        {
+            var libraryPath = TestPath("media", "movies");
+            var orphanPath = TestPath("media", "movies", "OrphanedMovieDir");
+
+            var virtualFolder = new VirtualFolderInfo
+            {
+                Name = "Movies",
+                CollectionType = CollectionTypeOptions.movies,
+                Locations = new[] { libraryPath }
+            };
+            _libraryManagerMock.Setup(m => m.GetVirtualFolders()).Returns(new List<VirtualFolderInfo> { virtualFolder });
+
+            _fileSystemMock.Setup(f => f.GetFiles(libraryPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+            _fileSystemMock.Setup(f => f.GetDirectories(libraryPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = orphanPath, Name = "OrphanedMovieDir", IsDirectory = true }
+            });
+
+            _fileSystemMock.Setup(f => f.GetFiles(orphanPath, false)).Returns(new[]
+            {
+                new FileSystemMetadata { FullName = TestPath(orphanPath, "poster.jpg"), Name = "poster.jpg", Length = 50_000, IsDirectory = false }
+            });
+            _fileSystemMock.Setup(f => f.GetDirectories(orphanPath, false)).Returns(Enumerable.Empty<FileSystemMetadata>());
+
+            var result = _service.CalculateStatistics();
+            var stats = result.Libraries[0];
+
+            Assert.Contains(orphanPath, stats.OrphanedMetadataDirectoriesPaths);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/PathValidatorTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/PathValidatorTests.cs
@@ -1,7 +1,7 @@
 using Jellyfin.Plugin.JellyfinHelper.Services;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services;
 
 /// <summary>
 /// Tests for <see cref="PathValidator"/>.

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/StatisticsSerializationRoundtripTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/StatisticsSerializationRoundtripTests.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 using Jellyfin.Plugin.JellyfinHelper.Services;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services;
 
 /// <summary>
 /// Roundtrip serialization tests to ensure statistics data survives JSON

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/StrmRepairServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/StrmRepairServiceTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services;
 
 public class StrmRepairServiceTests
 {

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/TrashServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/TrashServiceTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
-namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services;
 
 public class TrashServiceTests : IDisposable
 {

--- a/Jellyfin.Plugin.JellyfinHelper/Api/MediaStatisticsController.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Api/MediaStatisticsController.cs
@@ -569,7 +569,7 @@ public class MediaStatisticsController : ControllerBase
 
         return Ok(new
         {
-            UseTrash = config.UseTrash,
+            config.UseTrash,
             RetentionDays = config.TrashRetentionDays,
             Libraries = libraries,
         });
@@ -759,15 +759,24 @@ public class MediaStatisticsController : ControllerBase
 
         var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        var config = CleanupConfigHelper.GetConfig();
+        var trashFolderName = config.TrashFolderPath;
+        bool isTrashRelative = !Path.IsPathRooted(trashFolderName);
+
         foreach (var folder in folders)
         {
             foreach (var location in folder.Locations)
             {
                 try
                 {
-                    var dirs = _fileSystem.GetDirectories(location, false);
+                    var dirs = _fileSystem.GetDirectories(location);
                     foreach (var dir in dirs)
                     {
+                        if (isTrashRelative && string.Equals(dir.Name, trashFolderName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
                         result.Add(dir.Name);
                     }
                 }

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Settings.js
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Settings.js
@@ -79,7 +79,7 @@
             h += renderTaskModeSelect('cfgStrmMode', T('strmFileRepair', '.strm File Repair'), cfg.StrmRepairTaskMode || 'DryRun');
 
             h += '<div class="section-title">' + T('settingsTrashTitle', 'Trash settings') + '</div>';
-            h += '<div class="checkbox-row"><input type="checkbox" id="cfgTrash"' + (cfg.UseTrash ? ' checked' : '') + '><label>' + T('useTrash', 'Use Trash (Recycle Bin)') + '</label></div>';
+            h += '<div class="checkbox-row"><input type="checkbox" id="cfgTrash"' + (cfg.UseTrash ? ' checked' : '') + '><label for="cfgTrash">' + T('useTrash', 'Use Trash (Recycle Bin)') + '</label></div>';
             
             h += '<label>' + T('trashFolder', 'Trash Folder Path') + '</label>';
             h += '<input type="text" id="cfgTrashPath" value="' + escAttr(cfg.TrashFolderPath || '.jellyfin-trash') + '">';
@@ -196,7 +196,7 @@
         apiClient.ajax({
             type: 'GET', url: apiClient.getUrl('JellyfinHelper/Trash/Folders'), dataType: 'json'
         }).then(function (data) {
-            var paths = data.trashFolders || [];
+            var paths = data.Paths || [];
             if (paths.length === 0) {
                 doSaveSettings(payload);
                 return;

--- a/Jellyfin.Plugin.JellyfinHelper/Services/MediaStatisticsService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/MediaStatisticsService.cs
@@ -191,8 +191,18 @@ public partial class MediaStatisticsService
             // Recurse into subdirectories
             var subDirs = _fileSystem.GetDirectories(directoryPath);
             bool subDirHasVideo = false;
+
+            var config = CleanupConfigHelper.GetConfig();
+            var trashFolderName = config.TrashFolderPath;
+            bool isTrashRelative = !Path.IsPathRooted(trashFolderName);
+
             foreach (var subDir in subDirs)
             {
+                if (isTrashRelative && string.Equals(subDir.Name, trashFolderName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
                 if (subDir.Name.EndsWith(".trickplay", StringComparison.OrdinalIgnoreCase))
                 {
                     var trickplaySize = FileSystemHelper.CalculateDirectorySize(_fileSystem, subDir.FullName, _logger);

--- a/Jellyfin.Plugin.JellyfinHelper/Services/MediaStatisticsService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/MediaStatisticsService.cs
@@ -67,7 +67,7 @@ public partial class MediaStatisticsService
             foreach (var location in vf.Locations)
             {
                 _logger.LogDebug("Scanning library location: {Location} (type: {Type})", location, collectionType);
-                AnalyzeDirectoryRecursive(location, libraryStats, skipHealthChecks: skipHealth);
+                AnalyzeDirectoryRecursive(location, libraryStats, location, skipHealthChecks: skipHealth);
             }
 
             result.Libraries.Add(libraryStats);
@@ -98,8 +98,9 @@ public partial class MediaStatisticsService
     /// </summary>
     /// <param name="directoryPath">The directory to analyze.</param>
     /// <param name="stats">The statistics accumulator.</param>
+    /// <param name="libraryRoot">The library root path (used for trash folder resolution).</param>
     /// <param name="skipHealthChecks">When true, skip health check counters (e.g. for boxset/collection libraries).</param>
-    private bool AnalyzeDirectoryRecursive(string directoryPath, LibraryStatistics stats, bool skipHealthChecks = false)
+    private bool AnalyzeDirectoryRecursive(string directoryPath, LibraryStatistics stats, string? libraryRoot = null, bool skipHealthChecks = false)
     {
         bool containsVideo = false;
         try
@@ -195,10 +196,14 @@ public partial class MediaStatisticsService
             var config = CleanupConfigHelper.GetConfig();
             var trashFolderName = config.TrashFolderPath;
             bool isTrashRelative = !Path.IsPathRooted(trashFolderName);
+            var fullTrashPath = libraryRoot != null
+                ? Path.GetFullPath(isTrashRelative ? Path.Combine(libraryRoot, trashFolderName) : trashFolderName)
+                : null;
 
             foreach (var subDir in subDirs)
             {
-                if (isTrashRelative && string.Equals(subDir.Name, trashFolderName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(subDir.Name, trashFolderName, StringComparison.OrdinalIgnoreCase)
+                    || (fullTrashPath != null && string.Equals(Path.GetFullPath(subDir.FullName), fullTrashPath, StringComparison.OrdinalIgnoreCase)))
                 {
                     continue;
                 }
@@ -209,7 +214,7 @@ public partial class MediaStatisticsService
                     stats.TrickplaySize += trickplaySize;
                     stats.TrickplayFolderCount++;
                 }
-                else if (AnalyzeDirectoryRecursive(subDir.FullName, stats, skipHealthChecks))
+                else if (AnalyzeDirectoryRecursive(subDir.FullName, stats, libraryRoot, skipHealthChecks))
                 {
                     subDirHasVideo = true;
                     containsVideo = true;

--- a/Jellyfin.Plugin.JellyfinHelper/Services/MediaStatisticsService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/MediaStatisticsService.cs
@@ -194,16 +194,17 @@ public partial class MediaStatisticsService
             bool subDirHasVideo = false;
 
             var config = CleanupConfigHelper.GetConfig();
-            var trashFolderName = config.TrashFolderPath;
-            bool isTrashRelative = !Path.IsPathRooted(trashFolderName);
+            var trashFolderName = config.TrashFolderPath.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             var fullTrashPath = libraryRoot != null
-                ? Path.GetFullPath(isTrashRelative ? Path.Combine(libraryRoot, trashFolderName) : trashFolderName)
+                ? Path.GetFullPath(CleanupConfigHelper.GetTrashPath(libraryRoot)).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
                 : null;
 
             foreach (var subDir in subDirs)
             {
-                if (string.Equals(subDir.Name, trashFolderName, StringComparison.OrdinalIgnoreCase)
-                    || (fullTrashPath != null && string.Equals(Path.GetFullPath(subDir.FullName), fullTrashPath, StringComparison.OrdinalIgnoreCase)))
+                var normalizedSubDirFullName = Path.GetFullPath(subDir.FullName).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+                if (string.Equals(subDir.Name.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), trashFolderName, StringComparison.OrdinalIgnoreCase)
+                    || (fullTrashPath != null && string.Equals(normalizedSubDirFullName, fullTrashPath, StringComparison.OrdinalIgnoreCase)))
                 {
                     continue;
                 }
@@ -437,9 +438,7 @@ public partial class MediaStatisticsService
         }
 
         // Fall back to extension-based detection via MediaExtensions mapping
-        return MediaExtensions.AudioExtensionToCodec.TryGetValue(extension, out var codecFromExt)
-            ? codecFromExt
-            : "Unknown";
+        return MediaExtensions.AudioExtensionToCodec.GetValueOrDefault(extension, "Unknown");
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.JellyfinHelper/Services/MediaStatisticsService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/MediaStatisticsService.cs
@@ -99,11 +99,12 @@ public partial class MediaStatisticsService
     /// <param name="directoryPath">The directory to analyze.</param>
     /// <param name="stats">The statistics accumulator.</param>
     /// <param name="skipHealthChecks">When true, skip health check counters (e.g. for boxset/collection libraries).</param>
-    private void AnalyzeDirectoryRecursive(string directoryPath, LibraryStatistics stats, bool skipHealthChecks = false)
+    private bool AnalyzeDirectoryRecursive(string directoryPath, LibraryStatistics stats, bool skipHealthChecks = false)
     {
+        bool containsVideo = false;
         try
         {
-            var files = _fileSystem.GetFiles(directoryPath, false).ToList();
+            var files = _fileSystem.GetFiles(directoryPath).ToList();
 
             bool hasVideo = false;
             bool hasSubs = false;
@@ -122,6 +123,7 @@ public partial class MediaStatisticsService
                     stats.VideoSize += size;
                     stats.VideoFileCount++;
                     hasVideo = true;
+                    containsVideo = true;
 
                     // Container format tracking
                     var container = ext.TrimStart('.').ToUpperInvariant();
@@ -186,6 +188,24 @@ public partial class MediaStatisticsService
                 }
             }
 
+            // Recurse into subdirectories
+            var subDirs = _fileSystem.GetDirectories(directoryPath);
+            bool subDirHasVideo = false;
+            foreach (var subDir in subDirs)
+            {
+                if (subDir.Name.EndsWith(".trickplay", StringComparison.OrdinalIgnoreCase))
+                {
+                    var trickplaySize = FileSystemHelper.CalculateDirectorySize(_fileSystem, subDir.FullName, _logger);
+                    stats.TrickplaySize += trickplaySize;
+                    stats.TrickplayFolderCount++;
+                }
+                else if (AnalyzeDirectoryRecursive(subDir.FullName, stats, skipHealthChecks))
+                {
+                    subDirHasVideo = true;
+                    containsVideo = true;
+                }
+            }
+
             // Health checks — per-directory analysis
             // Boxset/collection libraries are excluded: they are Jellyfin-internal virtual folders
             // that group related movies and typically only contain posters/images, not real media.
@@ -230,24 +250,27 @@ public partial class MediaStatisticsService
                 }
                 else if (hasAnyNonTrickplayFile && (hasSubs || hasImage || hasNfo))
                 {
-                    stats.OrphanedMetadataDirectories++;
-                    stats.OrphanedMetadataDirectoriesPaths.Add(directoryPath);
-                }
-            }
+                    // Special case for TV Shows: Don't mark as orphaned if it contains subdirectories with videos
+                    // (e.g. "Series 1" folder containing "Season 01")
+                    // OR if it is a known TV show container folder (Specials, Season XX)
+                    bool isTvShow = string.Equals(stats.CollectionType, "tvshows", StringComparison.OrdinalIgnoreCase);
+                    bool isTvContainer = false;
+                    if (isTvShow)
+                    {
+                        var dirName = Path.GetFileName(directoryPath);
+                        if (string.Equals(dirName, "Specials", StringComparison.OrdinalIgnoreCase) ||
+                            dirName.StartsWith("Season ", StringComparison.OrdinalIgnoreCase) ||
+                            dirName.StartsWith("Staffel ", StringComparison.OrdinalIgnoreCase))
+                        {
+                            isTvContainer = true;
+                        }
+                    }
 
-            // Recurse into subdirectories
-            var subDirs = _fileSystem.GetDirectories(directoryPath, false);
-            foreach (var subDir in subDirs)
-            {
-                if (subDir.Name.EndsWith(".trickplay", StringComparison.OrdinalIgnoreCase))
-                {
-                    var trickplaySize = FileSystemHelper.CalculateDirectorySize(_fileSystem, subDir.FullName, _logger);
-                    stats.TrickplaySize += trickplaySize;
-                    stats.TrickplayFolderCount++;
-                }
-                else
-                {
-                    AnalyzeDirectoryRecursive(subDir.FullName, stats, skipHealthChecks);
+                    if (!isTvShow || (!subDirHasVideo && !isTvContainer))
+                    {
+                        stats.OrphanedMetadataDirectories++;
+                        stats.OrphanedMetadataDirectoriesPaths.Add(directoryPath);
+                    }
                 }
             }
         }
@@ -255,6 +278,8 @@ public partial class MediaStatisticsService
         {
             _logger.LogWarning(ex, "Could not access directory {Path}", directoryPath);
         }
+
+        return containsVideo;
     }
 
     /// <summary>

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,14 @@
     "imageUrl": "https://raw.githubusercontent.com/JellyPlugins/jellyfin-helper/main/media/logo.png",
     "versions": [
       {
+        "version": "1.0.6",
+        "changelog": "Exclude trash folders from media statistics, fix false positives for orphaned TV show metadata directories, fix trash disable dialog in UI.",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/JellyPlugins/jellyfin-helper/releases/download/1.0.6/JellyfinHelper_1.0.6.zip",
+        "checksum": "",
+        "timestamp": "2026-04-11T18:27:00Z"
+      },
+      {
         "version": "1.0.5",
         "changelog": "Multi-instance Arr support (up to 3 Radarr + 3 Sonarr), Arr connection test endpoint, persisted latest scan results (survives restarts), post-cleanup statistics scan, embedded subtitle detection in health checks, video vs music audio codec split, codec file path tracking with clickable drill-down, trash contents detail API, trash folder management UI, trash disable dialog, other file tracking, 6-tab modular dashboard (Overview/Codecs/Health/Trends/Settings/Arr), modular CSS/JS build system, XSS protection, boxset/collection health check skipping, comprehensive README rewrite, 573 tests.",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded trash folders from media statistics; fixed disable-trash confirmation and unsafe-deletion handling.

* **Improvements**
  * Reduced false positives for orphaned TV metadata; improved trickplay and trash-folder detection.
  * Better label association for the trash settings checkbox (accessibility).

* **Tests**
  * Added tests for trash discovery/deletion and media-statistics; reorganized test namespaces.

* **Documentation**
  * Changelog and manifest updated; release version bumped to v1.0.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->