### PR TITLE
Feature/discovery out of band reconcile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ test suite that runs the plugin inside a real Jellyfin server on every change.
 
 ### Tests
 - **New end-to-end test suite** - Alongside the unit tests, the plugin now runs inside a real Jellyfin 12 server (in a throwaway container, with stand-in Radarr/Sonarr/Jellyseerr services) and is exercised the way a real user would: changing settings, running each cleanup mode, importing/exporting a backup, and clicking through every dashboard tab. It also deliberately throws bad and hostile input at the plugin and uses "canary" files to prove that cleanup never deletes or touches anything outside your libraries, and that every admin-only action stays locked to admins. **294 tests across 46 files**, running automatically on every change plus a nightly full run.
-- **Unit tests: 5170 total** (+2845 vs. v2.1.0.6), including full coverage of the typed API responses.
+- **Unit tests: 5193 total** (+2868 vs. v2.1.0.6), including full coverage of the typed API responses.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ test suite that runs the plugin inside a real Jellyfin server on every change.
 
 ### Tests
 - **New end-to-end test suite** - Alongside the unit tests, the plugin now runs inside a real Jellyfin 12 server (in a throwaway container, with stand-in Radarr/Sonarr/Jellyseerr services) and is exercised the way a real user would: changing settings, running each cleanup mode, importing/exporting a backup, and clicking through every dashboard tab. It also deliberately throws bad and hostile input at the plugin and uses "canary" files to prove that cleanup never deletes or touches anything outside your libraries, and that every admin-only action stays locked to admins. **294 tests across 46 files**, running automatically on every change plus a nightly full run.
-- **Unit tests: 5193 total** (+2868 vs. v2.1.0.6), including full coverage of the typed API responses.
+- **Unit tests: 5196 total** (+2871 vs. v2.1.0.6), including full coverage of the typed API responses.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ test suite that runs the plugin inside a real Jellyfin server on every change.
 
 ### Tests
 - **New end-to-end test suite** - Alongside the unit tests, the plugin now runs inside a real Jellyfin 12 server (in a throwaway container, with stand-in Radarr/Sonarr/Jellyseerr services) and is exercised the way a real user would: changing settings, running each cleanup mode, importing/exporting a backup, and clicking through every dashboard tab. It also deliberately throws bad and hostile input at the plugin and uses "canary" files to prove that cleanup never deletes or touches anything outside your libraries, and that every admin-only action stays locked to admins. **294 tests across 46 files**, running automatically on every change plus a nightly full run.
-- **Unit tests: 5196 total** (+2871 vs. v2.1.0.6), including full coverage of the typed API responses.
+- **Unit tests: 5203 total** (+2878 vs. v2.1.0.6), including full coverage of the typed API responses.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,6 +258,7 @@ Jellyfin.Plugin.JellyfinHelper.Tests/
 │   │       ├── SeerrDiscoveryGenerationTests.cs         # Task-mode orchestration: Deactivate short-circuits, DryRun never writes feedback, cancellation propagates
 │   │       ├── SeerrDiscoveryServiceUserResolutionTests.cs # FindSeerrUserByJellyfinId, BuildAllowedProfileList
 │   │       ├── SeerrDiscoveryReconcileTests.cs         # ReconcileRequestedItemsAsync: records+marks cached items also requested out-of-band, per-user, media-type normalization, all fail-safe/pagination branches
+│   │       ├── SeerrDiscoveryReconcileFailureTests.cs  # Reconcile fail-safe catches: throwing feedback store (read and write) and an invalid Seerr URL reached after the roster was cached
 │   │       ├── SeerrDiscoveryServiceReasonTests.cs      # DetermineReason branches, threshold gates, priority ordering
 │   │       ├── SeerrPermissionExtensionsTests.cs        # SECURITY: HasPermission zero-flag, admin bypass, per-media-type flags, null-user throws
 │   │       └── TmdbDiscoverItemTests.cs                 # GenreIds null-coalesce, DisplayTitle fallback chain, EffectiveReleaseDate TV/movie, JSON round-trip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,6 +257,7 @@ Jellyfin.Plugin.JellyfinHelper.Tests/
 │   │       ├── SeerrDiscoveryServiceHttpTests.cs        # HTTP surface via scripted HttpMessageHandler: SubmitRequestAsync, GetServiceInfoAsync, user resolution, permissions
 │   │       ├── SeerrDiscoveryGenerationTests.cs         # Task-mode orchestration: Deactivate short-circuits, DryRun never writes feedback, cancellation propagates
 │   │       ├── SeerrDiscoveryServiceUserResolutionTests.cs # FindSeerrUserByJellyfinId, BuildAllowedProfileList
+│   │       ├── SeerrDiscoveryReconcileTests.cs         # ReconcileRequestedItemsAsync: records+marks cached items also requested out-of-band, per-user, media-type normalization, all fail-safe/pagination branches
 │   │       ├── SeerrDiscoveryServiceReasonTests.cs      # DetermineReason branches, threshold gates, priority ordering
 │   │       ├── SeerrPermissionExtensionsTests.cs        # SECURITY: HasPermission zero-flag, admin bypass, per-media-type flags, null-user throws
 │   │       └── TmdbDiscoverItemTests.cs                 # GenreIds null-coalesce, DisplayTitle fallback chain, EffectiveReleaseDate TV/movie, JSON round-trip
@@ -1303,6 +1304,8 @@ UserWatchProfiles → Genre/People/Language preferences
 - Uses `ExternalCandidateFeatureBuilder` to construct the same 38-feature vector used for internal recommendations
 - Results persisted to `jellyfin-helper-discovery-results.json` with in-memory cache
 - Request submission via `POST /JellyfinHelper/Discovery/Request` with optional Seerr user/server/profile mapping
+
+**Out-of-band request reconciliation:** `SeerrDiscoveryService.ReconcileRequestedItemsAsync(jellyfinUserId, ct)` folds requests a user made outside the discovery UI (e.g. directly in Jellyseerr) back into discovery. It resolves the Jellyfin user to their Seerr user id, paginates `GET /api/v1/request?requestedBy={seerrUserId}`, intersects the returned `(tmdbId, mediaType)` keys with the user's cached recommendations, and for each match records a positive `Requested` feedback signal (`IDiscoveryFeedbackStore.RecordRequested`) and marks it in the cache (`DiscoveryCacheService.MarkAsRequestedAsync`) - so the item leaves the visible pool and the next backfill item takes its slot, exactly like an in-discovery request. It is **fail-safe**: an unresolvable user, any Seerr HTTP/JSON error, or an incomplete pagination returns 0 and touches neither the feedback store nor the cache. It runs from two callers: lazily on the view-load path (`UserDiscoveryController.GetMyDiscoveryResults`, throttled per-user via `BuildReconcileKey` for `ReconcileTtl`) for instant UX, and authoritatively at the top of `GenerateForUserAsync` during the scheduled run so training benefits even for users who never open the sidebar.
 
 ### Discovery Custom Tab & Script Injection
 

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Api/UserDiscoveryControllerAccessEnabledTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Api/UserDiscoveryControllerAccessEnabledTests.cs
@@ -79,16 +79,16 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
     }
 
     [Fact]
-    public void GetMyDiscoveryResults_NoUserClaim_ReturnsUnauthorized()
+    public async Task GetMyDiscoveryResults_NoUserClaim_ReturnsUnauthorized()
     {
-        var result = CreateController(null).GetMyDiscoveryResults();
+        var result = await CreateController(null).GetMyDiscoveryResults(CancellationToken.None);
         Assert.IsType<UnauthorizedResult>(result.Result);
     }
 
     [Fact]
-    public void GetMyDiscoveryResults_UnknownUser_ReturnsOkWithNullBody()
+    public async Task GetMyDiscoveryResults_UnknownUser_ReturnsOkWithNullBody()
     {
-        var result = CreateController(Guid.NewGuid()).GetMyDiscoveryResults();
+        var result = await CreateController(Guid.NewGuid()).GetMyDiscoveryResults(CancellationToken.None);
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Null(ok.Value);
     }
@@ -239,7 +239,7 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
     }
 
     [Fact]
-    public void GetMyDiscoveryResults_KnownUser_ReturnsVisibleRecommendations_ExcludingDismissedAndRequestedAndAlreadyRequested()
+    public async Task GetMyDiscoveryResults_KnownUser_ReturnsVisibleRecommendations_ExcludingDismissedAndRequestedAndAlreadyRequested()
     {
         var userId = Guid.NewGuid();
         var generatedAt = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
@@ -269,7 +269,7 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
         _feedbackStoreMock.Setup(f => f.GetRequestedItems(userId))
             .Returns(new HashSet<(int, string)> { (3, "tv") });
 
-        var result = CreateController(userId).GetMyDiscoveryResults();
+        var result = await CreateController(userId).GetMyDiscoveryResults(CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var body = Assert.IsType<DiscoveryResult>(ok.Value);
@@ -280,7 +280,7 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
     }
 
     [Fact]
-    public void GetMyDiscoveryResults_ExclusionMatchesRegardlessOfMediaTypeCasing()
+    public async Task GetMyDiscoveryResults_ExclusionMatchesRegardlessOfMediaTypeCasing()
     {
         var userId = Guid.NewGuid();
         _discoveryMock.SetupGet(d => d.MaxVisiblePerUser).Returns(10);
@@ -303,7 +303,7 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
         _feedbackStoreMock.Setup(f => f.GetDismissedItems(userId))
             .Returns(new HashSet<(int, string)> { (7, "movie") });
 
-        var result = CreateController(userId).GetMyDiscoveryResults();
+        var result = await CreateController(userId).GetMyDiscoveryResults(CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var body = Assert.IsType<DiscoveryResult>(ok.Value);
@@ -311,7 +311,7 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
     }
 
     [Fact]
-    public void GetMyDiscoveryResults_CapsVisibleAtMaxVisiblePerUser()
+    public async Task GetMyDiscoveryResults_CapsVisibleAtMaxVisiblePerUser()
     {
         var userId = Guid.NewGuid();
         _discoveryMock.SetupGet(d => d.MaxVisiblePerUser).Returns(10);
@@ -324,7 +324,7 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
 
         _cache.Save(new List<DiscoveryResult> { result });
 
-        var response = CreateController(userId).GetMyDiscoveryResults();
+        var response = await CreateController(userId).GetMyDiscoveryResults(CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(response.Result);
         var body = Assert.IsType<DiscoveryResult>(ok.Value);
@@ -332,7 +332,7 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
     }
 
     [Fact]
-    public void GetMyDiscoveryResults_WhenFeedbackStoreThrows_LogsAndServesUnfilteredVisiblePool()
+    public async Task GetMyDiscoveryResults_WhenFeedbackStoreThrows_LogsAndServesUnfilteredVisiblePool()
     {
         var userId = Guid.NewGuid();
         _discoveryMock.SetupGet(d => d.MaxVisiblePerUser).Returns(10);
@@ -356,10 +356,142 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
         _feedbackStoreMock.Setup(f => f.GetDismissedItems(userId))
             .Throws(new InvalidOperationException("store unavailable"));
 
-        var response = CreateController(userId).GetMyDiscoveryResults();
+        var response = await CreateController(userId).GetMyDiscoveryResults(CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(response.Result);
         var body = Assert.IsType<DiscoveryResult>(ok.Value);
         Assert.Equal(new[] { 11, 12 }, body.Recommendations.Select(r => r.TmdbId).OrderBy(x => x).ToArray());
+    }
+
+    [Fact]
+    public async Task GetMyDiscoveryResults_InvokesReconcileBeforeReadingPool()
+    {
+        var userId = Guid.NewGuid();
+        _discoveryMock.SetupGet(d => d.MaxVisiblePerUser).Returns(10);
+
+        await CreateController(userId).GetMyDiscoveryResults(CancellationToken.None);
+
+        _discoveryMock.Verify(
+            d => d.ReconcileRequestedItemsAsync(userId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMyDiscoveryResults_ReconcilesAtMostOncePerTtlWindow()
+    {
+        var userId = Guid.NewGuid();
+        _discoveryMock.SetupGet(d => d.MaxVisiblePerUser).Returns(10);
+
+        // Two consecutive loads for the same user share one MemoryCache, so the second must be throttled.
+        var controller = CreateController(userId);
+        await controller.GetMyDiscoveryResults(CancellationToken.None);
+        await controller.GetMyDiscoveryResults(CancellationToken.None);
+
+        _discoveryMock.Verify(
+            d => d.ReconcileRequestedItemsAsync(userId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMyDiscoveryResults_WhenReconcileThrows_StillReturnsCachedView()
+    {
+        var userId = Guid.NewGuid();
+        _discoveryMock.SetupGet(d => d.MaxVisiblePerUser).Returns(10);
+        _discoveryMock
+            .Setup(d => d.ReconcileRequestedItemsAsync(userId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("seerr exploded"));
+
+        _cache.Save(new List<DiscoveryResult>
+        {
+            new()
+            {
+                UserId = userId,
+                UserName = "erin",
+                GeneratedAt = DateTime.UtcNow,
+                Recommendations =
+                {
+                    new DiscoveryRecommendation { TmdbId = 21, MediaType = "movie", AlreadyRequested = false }
+                }
+            }
+        });
+
+        var response = await CreateController(userId).GetMyDiscoveryResults(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(response.Result);
+        var body = Assert.IsType<DiscoveryResult>(ok.Value);
+        Assert.Equal(new[] { 21 }, body.Recommendations.Select(r => r.TmdbId).ToArray());
+    }
+
+    [Fact]
+    public async Task GetMyDiscoveryResults_AfterReconcileMarksItem_BackfillsNextItem()
+    {
+        var userId = Guid.NewGuid();
+        _discoveryMock.SetupGet(d => d.MaxVisiblePerUser).Returns(2);
+
+        _cache.Save(new List<DiscoveryResult>
+        {
+            new()
+            {
+                UserId = userId,
+                UserName = "frank",
+                GeneratedAt = DateTime.UtcNow,
+                Recommendations =
+                {
+                    new DiscoveryRecommendation { TmdbId = 31, MediaType = "movie", AlreadyRequested = false },
+                    new DiscoveryRecommendation { TmdbId = 32, MediaType = "movie", AlreadyRequested = false },
+                    new DiscoveryRecommendation { TmdbId = 33, MediaType = "movie", AlreadyRequested = false }
+                }
+            }
+        });
+
+        // Simulate reconciliation discovering that item 31 was requested out-of-band: it marks the
+        // cache entry and records the signal, exactly as the real service does.
+        _discoveryMock
+            .Setup(d => d.ReconcileRequestedItemsAsync(userId, It.IsAny<CancellationToken>()))
+            .Returns(async (Guid uid, CancellationToken ct) =>
+            {
+                await _cache.MarkAsRequestedAsync(31, "movie", uid, ct);
+                return 1;
+            });
+        _feedbackStoreMock.Setup(f => f.GetRequestedItems(userId))
+            .Returns(new HashSet<(int, string)>());
+
+        var response = await CreateController(userId).GetMyDiscoveryResults(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(response.Result);
+        var body = Assert.IsType<DiscoveryResult>(ok.Value);
+        // 31 marked requested and drops out; 32 and 33 become the visible top-2.
+        Assert.Equal(new[] { 32, 33 }, body.Recommendations.Select(r => r.TmdbId).OrderBy(x => x).ToArray());
+    }
+
+    [Fact]
+    public void BuildReconcileKey_HasExpectedFormat_AndSharesGenerationWithRateLimitKey()
+    {
+        var userId = Guid.NewGuid();
+        var reconcileKey = UserDiscoveryController.BuildReconcileKey(userId);
+        var rateLimitKey = UserDiscoveryController.BuildRateLimitKey(userId);
+
+        Assert.Contains("discovery:reconcile:", reconcileKey, StringComparison.Ordinal);
+        Assert.EndsWith(userId.ToString("N"), reconcileKey, StringComparison.Ordinal);
+
+        // Both keys embed the same generation segment so a plugin reload invalidates both together.
+        var reconcileGen = reconcileKey.Split(':')[3];
+        var rateLimitGen = rateLimitKey.Split(':')[3];
+        Assert.Equal(rateLimitGen, reconcileGen);
+    }
+
+    [Fact]
+    public async Task GetMyDiscoveryResults_WhenAccessDisabled_DoesNotReconcile()
+    {
+        Plugin.Instance!.Configuration.DiscoveryUserAccessEnabled = false;
+        _configServiceMock.Setup(s => s.GetConfiguration())
+            .Returns(new PluginConfiguration { DiscoveryUserAccessEnabled = false });
+
+        var response = await CreateController(Guid.NewGuid()).GetMyDiscoveryResults(CancellationToken.None);
+
+        Assert.IsType<ObjectResult>(response.Result);
+        _discoveryMock.Verify(
+            d => d.ReconcileRequestedItemsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Api/UserDiscoveryControllerAccessEnabledTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Api/UserDiscoveryControllerAccessEnabledTests.cs
@@ -31,6 +31,9 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
     private readonly Mock<IPluginConfigurationService> _configServiceMock;
     private readonly MemoryCache _memoryCache;
 
+    private static readonly int[] ExpectedSingleItem = [21];
+    private static readonly int[] ExpectedBackfillItems = [32, 33];
+
     public UserDiscoveryControllerAccessEnabledTests()
     {
         ControllerTestFactory.InitializePluginInstance();
@@ -419,7 +422,7 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
 
         var ok = Assert.IsType<OkObjectResult>(response.Result);
         var body = Assert.IsType<DiscoveryResult>(ok.Value);
-        Assert.Equal(new[] { 21 }, body.Recommendations.Select(r => r.TmdbId).ToArray());
+        Assert.Equal(ExpectedSingleItem, body.Recommendations.Select(r => r.TmdbId).ToArray());
     }
 
     [Fact]
@@ -461,7 +464,7 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
         var ok = Assert.IsType<OkObjectResult>(response.Result);
         var body = Assert.IsType<DiscoveryResult>(ok.Value);
         // 31 marked requested and drops out; 32 and 33 become the visible top-2.
-        Assert.Equal(new[] { 32, 33 }, body.Recommendations.Select(r => r.TmdbId).OrderBy(x => x).ToArray());
+        Assert.Equal(ExpectedBackfillItems, body.Recommendations.Select(r => r.TmdbId).OrderBy(x => x).ToArray());
     }
 
     [Fact]

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Api/UserDiscoveryControllerAccessEnabledTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Api/UserDiscoveryControllerAccessEnabledTests.cs
@@ -426,6 +426,41 @@ public sealed class UserDiscoveryControllerAccessEnabledTests : IDisposable
     }
 
     [Fact]
+    public async Task GetMyDiscoveryResults_WhenReconcileCancelled_SwallowsAndReturnsCachedView()
+    {
+        // The reconcile wrapper swallows an OperationCanceledException only when the caller's token
+        // is the one that cancelled, keeping the endpoint's "never fail on reconcile" contract.
+        var userId = Guid.NewGuid();
+        _discoveryMock.SetupGet(d => d.MaxVisiblePerUser).Returns(10);
+        _discoveryMock
+            .Setup(d => d.ReconcileRequestedItemsAsync(userId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        _cache.Save(new List<DiscoveryResult>
+        {
+            new()
+            {
+                UserId = userId,
+                UserName = "grace",
+                GeneratedAt = DateTime.UtcNow,
+                Recommendations =
+                {
+                    new DiscoveryRecommendation { TmdbId = 21, MediaType = "movie", AlreadyRequested = false }
+                }
+            }
+        });
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var response = await CreateController(userId).GetMyDiscoveryResults(cts.Token);
+
+        var ok = Assert.IsType<OkObjectResult>(response.Result);
+        var body = Assert.IsType<DiscoveryResult>(ok.Value);
+        Assert.Equal(ExpectedSingleItem, body.Recommendations.Select(r => r.TmdbId).ToArray());
+    }
+
+    [Fact]
     public async Task GetMyDiscoveryResults_AfterReconcileMarksItem_BackfillsNextItem()
     {
         var userId = Guid.NewGuid();

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Api/UserDiscoveryControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Api/UserDiscoveryControllerTests.cs
@@ -65,11 +65,11 @@ public class UserDiscoveryControllerTests
     }
 
     [Fact]
-    public void GetMyDiscoveryResults_WhenAccessDisabled_Returns403()
+    public async Task GetMyDiscoveryResults_WhenAccessDisabled_Returns403()
     {
         // DiscoveryUserAccessEnabled defaults to false when Plugin.Instance is null (test context)
         var controller = CreateController(Guid.NewGuid());
-        var result = controller.GetMyDiscoveryResults();
+        var result = await controller.GetMyDiscoveryResults(CancellationToken.None);
         var statusResult = Assert.IsType<ObjectResult>(result.Result);
         Assert.Equal(403, statusResult.StatusCode);
     }
@@ -172,11 +172,11 @@ public class UserDiscoveryControllerTests
     }
 
     [Fact]
-    public void GetMyDiscoveryResults_NoUserClaim_Returns403WhenDisabled()
+    public async Task GetMyDiscoveryResults_NoUserClaim_Returns403WhenDisabled()
     {
         // No userId claim
         var controller = CreateController(null);
-        var result = controller.GetMyDiscoveryResults();
+        var result = await controller.GetMyDiscoveryResults(CancellationToken.None);
         var statusResult = Assert.IsType<ObjectResult>(result.Result);
         // 403 because feature is disabled (checked before auth)
         Assert.Equal(403, statusResult.StatusCode);

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileFailureTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileFailureTests.cs
@@ -143,21 +143,20 @@ public sealed class SeerrDiscoveryReconcileFailureTests : IDisposable
     }
 
     [Fact]
-    public async Task Reconcile_WhenRecordRequestedThrows_SkipsItemWithoutFailing()
+    public async Task Reconcile_WhenRecordRequestedThrows_SkipsItemAndLeavesCacheUnstamped()
     {
         RegisterUserResolution();
         SeedCache(100, "movie");
         RegisterRequestPage((100, "movie"));
-        // The cache is stamped first, then the feedback write throws; the per-item catch swallows it
-        // so the item is not counted but the whole reconciliation still completes.
+        // The durable feedback signal is written first and throws, so the cache mark never runs.
+        // The item is not counted and the cache stays unstamped, so the next reconciliation retries.
         _feedbackStore.Setup(f => f.RecordRequested(JellyfinUserId, 100, "movie"))
             .Throws(new InvalidOperationException("feedback write failed"));
 
         var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
 
         Assert.Equal(0, count);
-        // The cache stamp happens before the failing feedback write, so it still took effect.
-        Assert.True(_cache.Load().First(r => r.UserId == JellyfinUserId).Recommendations.Single().AlreadyRequested);
+        Assert.False(_cache.Load().First(r => r.UserId == JellyfinUserId).Recommendations.Single().AlreadyRequested);
     }
 
     [Fact]

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileFailureTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileFailureTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinHelper.Services.Arr;
+using Jellyfin.Plugin.JellyfinHelper.Services.PluginLog;
+using Jellyfin.Plugin.JellyfinHelper.Services.Recommendation.Scoring;
+using Jellyfin.Plugin.JellyfinHelper.Services.Recommendation.WatchHistory;
+using Jellyfin.Plugin.JellyfinHelper.Services.Seerr.Discovery;
+using Jellyfin.Plugin.JellyfinHelper.Tests.TestFixtures;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services.Seerr.Discovery;
+
+/// <summary>
+///     Covers the fail-safe catch branches of discovery reconciliation that only fire when a
+///     dependency throws: a feedback store whose read or write fails, and an invalid Seerr URL
+///     reached after the user roster was already resolved from cache.
+/// </summary>
+[Collection("ConfigOverride")]
+public sealed class SeerrDiscoveryReconcileFailureTests : IDisposable
+{
+    private const int SeerrUserId = 42;
+    private static readonly Guid JellyfinUserId = new("11111111-2222-3333-4444-555555555555");
+    private const string JellyfinUserIdHex = "11111111222233334444555555555555";
+
+    private readonly ScriptedHttpHandler _handler;
+    private readonly SeerrDiscoveryService _sut;
+    private readonly DiscoveryCacheService _cache;
+    private readonly Mock<IDiscoveryFeedbackStore> _feedbackStore;
+    private readonly NeuralScoringStrategy _neural;
+    private readonly EnsembleScoringStrategy _ensemble;
+
+    public SeerrDiscoveryReconcileFailureTests()
+    {
+        ControllerTestFactory.InitializePluginInstance();
+        ControllerTestFactory.ResetPluginConfiguration();
+        Plugin.Instance!.Configuration.SeerrUrl = "https://seerr.example.com";
+        Plugin.Instance!.Configuration.SeerrApiKey = "test-api-key";
+
+        _handler = new ScriptedHttpHandler();
+
+        var httpFactory = new Mock<IHttpClientFactory>();
+        httpFactory
+            .Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(_handler, disposeHandler: false));
+
+        var pluginLog = new Mock<IPluginLogService>();
+        _cache = new DiscoveryCacheService(pluginLog.Object, new Mock<ILogger<DiscoveryCacheService>>().Object, filePath: Path.GetTempFileName());
+
+        _feedbackStore = new Mock<IDiscoveryFeedbackStore>();
+        _feedbackStore.Setup(f => f.GetDismissedItems(It.IsAny<Guid>()))
+            .Returns(new HashSet<(int, string)>());
+        _feedbackStore.Setup(f => f.GetRequestedItems(It.IsAny<Guid>()))
+            .Returns(new HashSet<(int, string)>());
+
+        var learned = new LearnedScoringStrategy(null, new Mock<ILogger<LearnedScoringStrategy>>().Object);
+        var heuristic = new HeuristicScoringStrategy(genrePenaltyFloor: 1.0);
+        _neural = new NeuralScoringStrategy(null, new Mock<ILogger<NeuralScoringStrategy>>().Object);
+        _ensemble = new EnsembleScoringStrategy(
+            learned, heuristic, _neural, null,
+            EnsembleScoringStrategy.DefaultAlphaMin,
+            EnsembleScoringStrategy.DefaultAlphaMax,
+            EnsembleScoringStrategy.DefaultGenrePenaltyFloor,
+            new Mock<ILogger<EnsembleScoringStrategy>>().Object);
+
+        _sut = new SeerrDiscoveryService(
+            httpFactory.Object,
+            new Mock<IWatchHistoryService>().Object,
+            new Mock<IArrIntegrationService>().Object,
+            _ensemble,
+            _cache,
+            _feedbackStore.Object,
+            pluginLog.Object,
+            new Mock<ILogger<SeerrDiscoveryService>>().Object);
+    }
+
+    public void Dispose()
+    {
+        _handler.Dispose();
+        _cache.Dispose();
+        _ensemble.Dispose();
+        _neural.Dispose();
+        ControllerTestFactory.ResetPluginConfiguration();
+    }
+
+    private void RegisterUserResolution()
+    {
+        var json = $$"""
+        {
+          "pageInfo": { "pages": 1, "pageSize": 50, "results": 1, "page": 1 },
+          "results": [ { "id": {{SeerrUserId}}, "displayName": "alice", "jellyfinUserId": "{{JellyfinUserIdHex}}" } ]
+        }
+        """;
+        _handler.RegisterResponse(HttpMethod.Get, "/api/v1/user", HttpStatusCode.OK, json);
+    }
+
+    private void RegisterRequestPage(params (int TmdbId, string MediaType)[] items)
+    {
+        var rows = string.Join(",\n", Array.ConvertAll(items, i =>
+            $$"""{ "id": {{i.TmdbId}}, "status": 2, "media": { "tmdbId": {{i.TmdbId}}, "mediaType": "{{i.MediaType}}", "status": 3 } }"""));
+        var body = $$"""
+        {
+          "pageInfo": { "pages": 1, "pageSize": 50, "results": {{items.Length}}, "page": 1 },
+          "results": [ {{rows}} ]
+        }
+        """;
+        _handler.RegisterResponse(HttpMethod.Get, $"requestedBy={SeerrUserId}", HttpStatusCode.OK, body);
+    }
+
+    private void SeedCache(int tmdbId, string mediaType)
+    {
+        var result = new DiscoveryResult
+        {
+            UserId = JellyfinUserId,
+            UserName = "alice",
+            GeneratedAt = DateTime.UtcNow
+        };
+        result.Recommendations.Add(new DiscoveryRecommendation { TmdbId = tmdbId, MediaType = mediaType, Title = $"item-{tmdbId}" });
+        _cache.Save(new List<DiscoveryResult> { result });
+    }
+
+    [Fact]
+    public async Task Reconcile_WhenGetRequestedItemsThrows_TreatsNothingAsAlreadyRecordedAndStillReconciles()
+    {
+        RegisterUserResolution();
+        SeedCache(100, "movie");
+        RegisterRequestPage((100, "movie"));
+        // The already-recorded lookup fails; reconciliation must fall back to an empty set and proceed.
+        _feedbackStore.Setup(f => f.GetRequestedItems(JellyfinUserId))
+            .Throws(new InvalidOperationException("feedback read failed"));
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(1, count);
+        _feedbackStore.Verify(f => f.RecordRequested(JellyfinUserId, 100, "movie"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Reconcile_WhenRecordRequestedThrows_SkipsItemWithoutFailing()
+    {
+        RegisterUserResolution();
+        SeedCache(100, "movie");
+        RegisterRequestPage((100, "movie"));
+        // The cache is stamped first, then the feedback write throws; the per-item catch swallows it
+        // so the item is not counted but the whole reconciliation still completes.
+        _feedbackStore.Setup(f => f.RecordRequested(JellyfinUserId, 100, "movie"))
+            .Throws(new InvalidOperationException("feedback write failed"));
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+        // The cache stamp happens before the failing feedback write, so it still took effect.
+        Assert.True(_cache.Load().First(r => r.UserId == JellyfinUserId).Recommendations.Single().AlreadyRequested);
+    }
+
+    [Fact]
+    public async Task Reconcile_WhenUrlBecomesInvalidAfterRosterCached_ReturnsZeroAndTouchesNothing()
+    {
+        RegisterUserResolution();
+        SeedCache(100, "movie");
+        RegisterRequestPage((100, "movie"));
+
+        // Prime the 5-minute Seerr user roster cache with the valid URL.
+        var primed = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+        Assert.Equal(1, primed);
+        _feedbackStore.Invocations.Clear();
+
+        // Now corrupt the URL. Resolution still returns the cached user, but the request fetch
+        // re-validates the config and hits the invalid-configuration catch.
+        Plugin.Instance!.Configuration.SeerrUrl = "not a valid url";
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+        _feedbackStore.Verify(f => f.RecordRequested(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileTests.cs
@@ -1,0 +1,392 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinHelper.Services.Arr;
+using Jellyfin.Plugin.JellyfinHelper.Services.PluginLog;
+using Jellyfin.Plugin.JellyfinHelper.Services.Recommendation.Scoring;
+using Jellyfin.Plugin.JellyfinHelper.Services.Recommendation.WatchHistory;
+using Jellyfin.Plugin.JellyfinHelper.Services.Seerr.Discovery;
+using Jellyfin.Plugin.JellyfinHelper.Tests.TestFixtures;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinHelper.Tests.Services.Seerr.Discovery;
+
+/// <summary>
+///     Tests SeerrDiscoveryService.ReconcileRequestedItemsAsync end to end against a real feedback store and cache, driving the Seerr user-resolution and requestedBy-scoped request endpoints through a scripted HttpMessageHandler.
+/// </summary>
+[Collection("ConfigOverride")]
+public sealed class SeerrDiscoveryReconcileTests : IDisposable
+{
+    private const int SeerrUserId = 42;
+    private static readonly Guid JellyfinUserId = new("11111111-2222-3333-4444-555555555555");
+    private const string JellyfinUserIdHex = "11111111222233334444555555555555";
+
+    private readonly ScriptedHttpHandler _handler;
+    private readonly SeerrDiscoveryService _sut;
+    private readonly DiscoveryCacheService _cache;
+    private readonly DiscoveryFeedbackStore _feedbackStore;
+    private readonly string _feedbackDir;
+
+    public SeerrDiscoveryReconcileTests()
+    {
+        ControllerTestFactory.InitializePluginInstance();
+        ControllerTestFactory.ResetPluginConfiguration();
+        Plugin.Instance!.Configuration.SeerrUrl = "https://seerr.example.com";
+        Plugin.Instance!.Configuration.SeerrApiKey = "test-api-key";
+
+        _handler = new ScriptedHttpHandler();
+
+        var httpFactory = new Mock<IHttpClientFactory>();
+        httpFactory
+            .Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(_handler, disposeHandler: false));
+
+        var pluginLog = new Mock<IPluginLogService>();
+        _cache = new DiscoveryCacheService(pluginLog.Object, new Mock<ILogger<DiscoveryCacheService>>().Object, filePath: Path.GetTempFileName());
+
+        _feedbackDir = Path.Join(Path.GetTempPath(), "reconcile-fb-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_feedbackDir);
+        _feedbackStore = new DiscoveryFeedbackStore(pluginLog.Object, new Mock<ILogger<DiscoveryFeedbackStore>>().Object, _feedbackDir);
+
+        var learned = new LearnedScoringStrategy(null, new Mock<ILogger<LearnedScoringStrategy>>().Object);
+        var heuristic = new HeuristicScoringStrategy(genrePenaltyFloor: 1.0);
+        var neural = new NeuralScoringStrategy(null, new Mock<ILogger<NeuralScoringStrategy>>().Object);
+        var ensemble = new EnsembleScoringStrategy(
+            learned, heuristic, neural, null,
+            EnsembleScoringStrategy.DefaultAlphaMin,
+            EnsembleScoringStrategy.DefaultAlphaMax,
+            EnsembleScoringStrategy.DefaultGenrePenaltyFloor,
+            new Mock<ILogger<EnsembleScoringStrategy>>().Object);
+
+        _sut = new SeerrDiscoveryService(
+            httpFactory.Object,
+            new Mock<IWatchHistoryService>().Object,
+            new Mock<IArrIntegrationService>().Object,
+            ensemble,
+            _cache,
+            _feedbackStore,
+            pluginLog.Object,
+            new Mock<ILogger<SeerrDiscoveryService>>().Object);
+    }
+
+    public void Dispose()
+    {
+        _handler.Dispose();
+        _cache.Dispose();
+        ControllerTestFactory.ResetPluginConfiguration();
+        try
+        {
+            Directory.Delete(_feedbackDir, recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best effort test cleanup.
+        }
+    }
+
+    private void RegisterUserResolution()
+    {
+        var json = $$"""
+        {
+          "pageInfo": { "pages": 1, "pageSize": 50, "results": 1, "page": 1 },
+          "results": [ { "id": {{SeerrUserId}}, "displayName": "alice", "jellyfinUserId": "{{JellyfinUserIdHex}}" } ]
+        }
+        """;
+        _handler.RegisterResponse(HttpMethod.Get, "/api/v1/user", HttpStatusCode.OK, json);
+    }
+
+    private void RegisterRequestPage(string body)
+    {
+        // The requestedBy segment is last in the query string, so registering it as the suffix
+        // is sufficient for the scripted handler's EndsWith match.
+        _handler.RegisterResponse(HttpMethod.Get, $"requestedBy={SeerrUserId}", HttpStatusCode.OK, body);
+    }
+
+    private void SeedCache(params DiscoveryRecommendation[] recommendations)
+    {
+        var result = new DiscoveryResult
+        {
+            UserId = JellyfinUserId,
+            UserName = "alice",
+            GeneratedAt = DateTime.UtcNow
+        };
+        foreach (var rec in recommendations)
+        {
+            result.Recommendations.Add(rec);
+        }
+
+        _cache.Save(new List<DiscoveryResult> { result });
+    }
+
+    private static DiscoveryRecommendation Rec(int tmdbId, string mediaType) =>
+        new() { TmdbId = tmdbId, MediaType = mediaType, Title = $"item-{tmdbId}" };
+
+    private static string RequestPageJson(params (int TmdbId, string MediaType)[] items)
+    {
+        var rows = string.Join(",\n", items.Select(i =>
+            $$"""{ "id": {{i.TmdbId}}, "status": 2, "media": { "tmdbId": {{i.TmdbId}}, "mediaType": "{{i.MediaType}}", "status": 3 } }"""));
+        return $$"""
+        {
+          "pageInfo": { "pages": 1, "pageSize": 50, "results": {{items.Length}}, "page": 1 },
+          "results": [ {{rows}} ]
+        }
+        """;
+    }
+
+    [Fact]
+    public async Task Reconcile_RecordsAndMarksOnlyCachedItemsAlsoRequestedInSeerr()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(100, "movie"), Rec(200, "tv"), Rec(300, "movie"));
+        // Seerr reports 100 and 200 requested; 300 was never requested; 999 is requested but not in the pool.
+        RegisterRequestPage(RequestPageJson((100, "movie"), (200, "tv"), (999, "movie")));
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(2, count);
+        var requested = _feedbackStore.GetRequestedItems(JellyfinUserId);
+        Assert.Contains((100, "movie"), requested);
+        Assert.Contains((200, "tv"), requested);
+        Assert.DoesNotContain((300, "movie"), requested);
+        // 999 was never in the cached pool, so no phantom feedback entry is created.
+        Assert.DoesNotContain((999, "movie"), requested);
+
+        var pool = _cache.Load().First(r => r.UserId == JellyfinUserId).Recommendations;
+        Assert.True(pool.Single(r => r.TmdbId == 100).AlreadyRequested);
+        Assert.True(pool.Single(r => r.TmdbId == 200).AlreadyRequested);
+        Assert.False(pool.Single(r => r.TmdbId == 300).AlreadyRequested);
+    }
+
+    [Fact]
+    public async Task Reconcile_ItemRequestedButNotInPool_IsNoOp()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(100, "movie"));
+        RegisterRequestPage(RequestPageJson((555, "movie")));
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+        Assert.Empty(_feedbackStore.GetRequestedItems(JellyfinUserId));
+    }
+
+    [Fact]
+    public async Task Reconcile_IsIdempotent_AlreadyRecordedItemsAreSkipped()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(100, "movie"));
+        RegisterRequestPage(RequestPageJson((100, "movie")));
+
+        var first = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+        var second = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(1, first);
+        Assert.Equal(0, second);
+    }
+
+    [Fact]
+    public async Task Reconcile_DistinguishesMovieAndTvWithSameTmdbId()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(550, "movie"), Rec(550, "tv"));
+        // Only the TV variant of 550 was requested.
+        RegisterRequestPage(RequestPageJson((550, "tv")));
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(1, count);
+        var requested = _feedbackStore.GetRequestedItems(JellyfinUserId);
+        Assert.Contains((550, "tv"), requested);
+        Assert.DoesNotContain((550, "movie"), requested);
+    }
+
+    [Fact]
+    public async Task Reconcile_NormalizesMediaTypeCasingAndUnknownValues()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(100, "  Movie "), Rec(200, "TV"));
+        // Seerr returns mixed-case and an unknown type that must collapse to movie.
+        RegisterRequestPage(RequestPageJson((100, "MOVIE"), (200, "Tv")));
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(2, count);
+        var requested = _feedbackStore.GetRequestedItems(JellyfinUserId);
+        Assert.Contains((100, "movie"), requested);
+        Assert.Contains((200, "tv"), requested);
+    }
+
+    [Fact]
+    public async Task Reconcile_EmptyGuid_ReturnsZero()
+    {
+        var count = await _sut.ReconcileRequestedItemsAsync(Guid.Empty, CancellationToken.None);
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task Reconcile_NotConfigured_ReturnsZero()
+    {
+        Plugin.Instance!.Configuration.SeerrUrl = string.Empty;
+        SeedCache(Rec(100, "movie"));
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+        Assert.Empty(_feedbackStore.GetRequestedItems(JellyfinUserId));
+    }
+
+    [Fact]
+    public async Task Reconcile_UserNotResolvable_ReturnsZeroAndTouchesNothing()
+    {
+        // Roster fetched but no matching Jellyfin user -> ResolveSeerrUserIdAsync returns null.
+        var json = """
+        {
+          "pageInfo": { "pages": 1, "pageSize": 50, "results": 1, "page": 1 },
+          "results": [ { "id": 7, "displayName": "stranger", "jellyfinUserId": "ffffffffffffffffffffffffffffffff" } ]
+        }
+        """;
+        _handler.RegisterResponse(HttpMethod.Get, "/api/v1/user", HttpStatusCode.OK, json);
+        SeedCache(Rec(100, "movie"));
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+        Assert.Empty(_feedbackStore.GetRequestedItems(JellyfinUserId));
+    }
+
+    [Fact]
+    public async Task Reconcile_RequestEndpointReturnsError_ReturnsZeroAndTouchesNothing()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(100, "movie"));
+        _handler.RegisterResponse(HttpMethod.Get, $"requestedBy={SeerrUserId}", HttpStatusCode.InternalServerError, "boom");
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+        Assert.Empty(_feedbackStore.GetRequestedItems(JellyfinUserId));
+        Assert.False(_cache.Load().First(r => r.UserId == JellyfinUserId).Recommendations.Single().AlreadyRequested);
+    }
+
+    [Fact]
+    public async Task Reconcile_RequestEndpointReturnsGarbageJson_ReturnsZero()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(100, "movie"));
+        _handler.RegisterResponse(HttpMethod.Get, $"requestedBy={SeerrUserId}", HttpStatusCode.OK, "{ not-json ");
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+        Assert.Empty(_feedbackStore.GetRequestedItems(JellyfinUserId));
+    }
+
+    [Fact]
+    public async Task Reconcile_RequestTransportException_ReturnsZero()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(100, "movie"));
+        // The user roster resolves from the first call; the second call (request page) throws.
+        _handler.ThrowAfter = new HttpRequestException("connection refused");
+        _handler.ThrowAfterCallIndex = 1;
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+        Assert.Empty(_feedbackStore.GetRequestedItems(JellyfinUserId));
+    }
+
+    [Fact]
+    public async Task Reconcile_EmptyRequestList_ReturnsZero()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(100, "movie"));
+        RegisterRequestPage(RequestPageJson());
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task Reconcile_NoCachedResultsForUser_ReturnsZero()
+    {
+        RegisterUserResolution();
+        RegisterRequestPage(RequestPageJson((100, "movie")));
+        // No SeedCache call: the user has no cached discovery pool.
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task Reconcile_PaginatesAcrossMultiplePages()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(1, "movie"), Rec(2, "movie"));
+
+        // Page 1 returns a full page (50 rows) so pagination continues; item 1 is on page 1.
+        var page1Rows = string.Join(",\n", Enumerable.Range(1000, 50).Select(i =>
+            $$"""{ "id": {{i}}, "status": 2, "media": { "tmdbId": {{(i == 1000 ? 1 : i)}}, "mediaType": "movie", "status": 3 } }"""));
+        var page1 = $$"""
+        { "pageInfo": { "pages": 2, "pageSize": 50, "results": 51, "page": 1 }, "results": [ {{page1Rows}} ] }
+        """;
+        var page2 = $$"""
+        { "pageInfo": { "pages": 2, "pageSize": 50, "results": 51, "page": 2 }, "results": [ { "id": 2, "status": 2, "media": { "tmdbId": 2, "mediaType": "movie", "status": 3 } } ] }
+        """;
+        _handler.RegisterResponse(HttpMethod.Get, $"skip=0&sort=added&filter=all&requestedBy={SeerrUserId}", HttpStatusCode.OK, page1);
+        _handler.RegisterResponse(HttpMethod.Get, $"skip=50&sort=added&filter=all&requestedBy={SeerrUserId}", HttpStatusCode.OK, page2);
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        // Item 1 (page 1) and item 2 (page 2) are both reconciled.
+        Assert.Equal(2, count);
+        var requested = _feedbackStore.GetRequestedItems(JellyfinUserId);
+        Assert.Contains((1, "movie"), requested);
+        Assert.Contains((2, "movie"), requested);
+    }
+
+    [Fact]
+    public async Task Reconcile_SkipsRowsWithMissingOrInvalidMedia()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(100, "movie"));
+        // One row has null media, one has tmdbId 0, one is the valid target.
+        var body = """
+        {
+          "pageInfo": { "pages": 1, "pageSize": 50, "results": 3, "page": 1 },
+          "results": [
+            { "id": 1, "status": 2, "media": null },
+            { "id": 2, "status": 2, "media": { "tmdbId": 0, "mediaType": "movie", "status": 3 } },
+            { "id": 3, "status": 2, "media": { "tmdbId": 100, "mediaType": "movie", "status": 3 } }
+          ]
+        }
+        """;
+        RegisterRequestPage(body);
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(1, count);
+        Assert.Contains((100, "movie"), _feedbackStore.GetRequestedItems(JellyfinUserId));
+    }
+
+    [Fact]
+    public async Task Reconcile_CancelledToken_Throws()
+    {
+        RegisterUserResolution();
+        SeedCache(Rec(100, "movie"));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _sut.ReconcileRequestedItemsAsync(JellyfinUserId, cts.Token));
+    }
+}

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileTests.cs
@@ -32,6 +32,7 @@ public sealed class SeerrDiscoveryReconcileTests : IDisposable
     private readonly SeerrDiscoveryService _sut;
     private readonly DiscoveryCacheService _cache;
     private readonly DiscoveryFeedbackStore _feedbackStore;
+    private readonly NeuralScoringStrategy _neural;
     private readonly EnsembleScoringStrategy _ensemble;
     private readonly string _feedbackDir;
 
@@ -58,9 +59,9 @@ public sealed class SeerrDiscoveryReconcileTests : IDisposable
 
         var learned = new LearnedScoringStrategy(null, new Mock<ILogger<LearnedScoringStrategy>>().Object);
         var heuristic = new HeuristicScoringStrategy(genrePenaltyFloor: 1.0);
-        var neural = new NeuralScoringStrategy(null, new Mock<ILogger<NeuralScoringStrategy>>().Object);
+        _neural = new NeuralScoringStrategy(null, new Mock<ILogger<NeuralScoringStrategy>>().Object);
         _ensemble = new EnsembleScoringStrategy(
-            learned, heuristic, neural, null,
+            learned, heuristic, _neural, null,
             EnsembleScoringStrategy.DefaultAlphaMin,
             EnsembleScoringStrategy.DefaultAlphaMax,
             EnsembleScoringStrategy.DefaultGenrePenaltyFloor,
@@ -82,6 +83,10 @@ public sealed class SeerrDiscoveryReconcileTests : IDisposable
         _handler.Dispose();
         _cache.Dispose();
         _ensemble.Dispose();
+        // The ensemble disposes the neural strategy transitively, but the analyzer tracks the
+        // locally constructed instance, so dispose it directly too. ReaderWriterLockSlim.Dispose
+        // is idempotent, so the double free is safe.
+        _neural.Dispose();
         ControllerTestFactory.ResetPluginConfiguration();
         try
         {
@@ -462,6 +467,65 @@ public sealed class SeerrDiscoveryReconcileTests : IDisposable
         var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
 
         Assert.Equal(0, count);
+        Assert.Empty(_feedbackStore.GetRequestedItems(JellyfinUserId));
+    }
+
+    [Fact]
+    public async Task Reconcile_FullPageWithTotalExactlyEqualToSkip_CompletesAfterOnePage()
+    {
+        // A full page whose reported total equals the next skip is a clean single-page result.
+        RegisterUserResolution();
+        SeedCache(Rec(1, "movie"));
+        var rows = string.Join(",\n", Enumerable.Range(1000, 50).Select(i =>
+            $$"""{ "id": {{i}}, "status": 2, "media": { "tmdbId": {{(i == 1000 ? 1 : i)}}, "mediaType": "movie", "status": 3 } }"""));
+        var page = $$"""
+        { "pageInfo": { "pages": 1, "pageSize": 50, "results": 50, "page": 1 }, "results": [ {{rows}} ] }
+        """;
+        RegisterRequestPage(page);
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(1, count);
+        Assert.Contains((1, "movie"), _feedbackStore.GetRequestedItems(JellyfinUserId));
+    }
+
+    [Fact]
+    public async Task Reconcile_RequestRowWithWhitespaceMediaType_NormalizesToMovie()
+    {
+        // A blank media type on the request row must collapse to movie so it still matches a
+        // cached movie recommendation.
+        RegisterUserResolution();
+        SeedCache(Rec(100, "movie"));
+        var body = """
+        {
+          "pageInfo": { "pages": 1, "pageSize": 50, "results": 1, "page": 1 },
+          "results": [ { "id": 100, "status": 2, "media": { "tmdbId": 100, "mediaType": "   ", "status": 3 } } ]
+        }
+        """;
+        RegisterRequestPage(body);
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(1, count);
+        Assert.Contains((100, "movie"), _feedbackStore.GetRequestedItems(JellyfinUserId));
+    }
+
+    [Fact]
+    public async Task Reconcile_TokenCancelledBetweenRosterAndFetch_Throws()
+    {
+        // The roster resolves from the first call, then the token is cancelled so the pagination
+        // loop's cooperative cancellation check throws before the request page is fetched.
+        RegisterUserResolution();
+        SeedCache(Rec(100, "movie"));
+        RegisterRequestPage(RequestPageJson((100, "movie")));
+
+        using var cts = new CancellationTokenSource();
+        _handler.CancelAfter = cts;
+        _handler.CancelAfterCallIndex = 0;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _sut.ReconcileRequestedItemsAsync(JellyfinUserId, cts.Token));
+
         Assert.Empty(_feedbackStore.GetRequestedItems(JellyfinUserId));
     }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileTests.cs
@@ -32,6 +32,7 @@ public sealed class SeerrDiscoveryReconcileTests : IDisposable
     private readonly SeerrDiscoveryService _sut;
     private readonly DiscoveryCacheService _cache;
     private readonly DiscoveryFeedbackStore _feedbackStore;
+    private readonly EnsembleScoringStrategy _ensemble;
     private readonly string _feedbackDir;
 
     public SeerrDiscoveryReconcileTests()
@@ -58,7 +59,7 @@ public sealed class SeerrDiscoveryReconcileTests : IDisposable
         var learned = new LearnedScoringStrategy(null, new Mock<ILogger<LearnedScoringStrategy>>().Object);
         var heuristic = new HeuristicScoringStrategy(genrePenaltyFloor: 1.0);
         var neural = new NeuralScoringStrategy(null, new Mock<ILogger<NeuralScoringStrategy>>().Object);
-        var ensemble = new EnsembleScoringStrategy(
+        _ensemble = new EnsembleScoringStrategy(
             learned, heuristic, neural, null,
             EnsembleScoringStrategy.DefaultAlphaMin,
             EnsembleScoringStrategy.DefaultAlphaMax,
@@ -69,7 +70,7 @@ public sealed class SeerrDiscoveryReconcileTests : IDisposable
             httpFactory.Object,
             new Mock<IWatchHistoryService>().Object,
             new Mock<IArrIntegrationService>().Object,
-            ensemble,
+            _ensemble,
             _cache,
             _feedbackStore,
             pluginLog.Object,
@@ -80,6 +81,7 @@ public sealed class SeerrDiscoveryReconcileTests : IDisposable
     {
         _handler.Dispose();
         _cache.Dispose();
+        _ensemble.Dispose();
         ControllerTestFactory.ResetPluginConfiguration();
         try
         {
@@ -388,5 +390,78 @@ public sealed class SeerrDiscoveryReconcileTests : IDisposable
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
             _sut.ReconcileRequestedItemsAsync(JellyfinUserId, cts.Token));
+    }
+
+    [Fact]
+    public async Task Reconcile_FullPageWithTotalBelowSkip_TreatsSnapshotAsIncompleteAndTouchesNothing()
+    {
+        // A full page (50 rows) whose reported total is smaller than the next skip is inconsistent
+        // pagination metadata. The fetch must fail closed rather than act on the partial snapshot.
+        RegisterUserResolution();
+        SeedCache(Rec(1000, "movie"));
+        var rows = string.Join(",\n", Enumerable.Range(1000, 50).Select(i =>
+            $$"""{ "id": {{i}}, "status": 2, "media": { "tmdbId": {{i}}, "mediaType": "movie", "status": 3 } }"""));
+        var page = $$"""
+        { "pageInfo": { "pages": 1, "pageSize": 50, "results": 10, "page": 1 }, "results": [ {{rows}} ] }
+        """;
+        RegisterRequestPage(page);
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+        Assert.Empty(_feedbackStore.GetRequestedItems(JellyfinUserId));
+        Assert.False(_cache.Load().First(r => r.UserId == JellyfinUserId).Recommendations.Single().AlreadyRequested);
+    }
+
+    [Fact]
+    public async Task Reconcile_FullPageWithMissingTotal_KeepsPagingUntilShortPage()
+    {
+        // A full page reporting a zero/absent total must not be trusted as complete. Reconciliation
+        // keeps paging until a short page and reconciles items found across both pages.
+        RegisterUserResolution();
+        SeedCache(Rec(1, "movie"), Rec(2, "movie"));
+
+        var page1Rows = string.Join(",\n", Enumerable.Range(1000, 50).Select(i =>
+            $$"""{ "id": {{i}}, "status": 2, "media": { "tmdbId": {{(i == 1000 ? 1 : i)}}, "mediaType": "movie", "status": 3 } }"""));
+        var page1 = $$"""
+        { "pageInfo": { "pages": 1, "pageSize": 50, "results": 0, "page": 1 }, "results": [ {{page1Rows}} ] }
+        """;
+        var page2 = $$"""
+        { "pageInfo": { "pages": 1, "pageSize": 50, "results": 0, "page": 2 }, "results": [ { "id": 2, "status": 2, "media": { "tmdbId": 2, "mediaType": "movie", "status": 3 } } ] }
+        """;
+        _handler.RegisterResponse(HttpMethod.Get, $"skip=0&sort=added&filter=all&requestedBy={SeerrUserId}", HttpStatusCode.OK, page1);
+        _handler.RegisterResponse(HttpMethod.Get, $"skip=50&sort=added&filter=all&requestedBy={SeerrUserId}", HttpStatusCode.OK, page2);
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(2, count);
+        var requested = _feedbackStore.GetRequestedItems(JellyfinUserId);
+        Assert.Contains((1, "movie"), requested);
+        Assert.Contains((2, "movie"), requested);
+    }
+
+    [Fact]
+    public async Task Reconcile_HitsPageCapWithoutExhaustingResults_ReturnsZeroAndTouchesNothing()
+    {
+        // Every page is full and the reported total always exceeds the next skip, so the scan never
+        // completes and hits the 20-page cap. That is a partial snapshot and must reconcile nothing.
+        RegisterUserResolution();
+        SeedCache(Rec(1, "movie"));
+        for (var pageIndex = 0; pageIndex < 20; pageIndex++)
+        {
+            var skip = pageIndex * 50;
+            var baseId = 1000 + skip;
+            var rows = string.Join(",\n", Enumerable.Range(baseId, 50).Select(i =>
+                $$"""{ "id": {{i}}, "status": 2, "media": { "tmdbId": {{(i == 1000 ? 1 : i)}}, "mediaType": "movie", "status": 3 } }"""));
+            var body = $$"""
+            { "pageInfo": { "pages": 999, "pageSize": 50, "results": 100000, "page": {{pageIndex + 1}} }, "results": [ {{rows}} ] }
+            """;
+            _handler.RegisterResponse(HttpMethod.Get, $"skip={skip}&sort=added&filter=all&requestedBy={SeerrUserId}", HttpStatusCode.OK, body);
+        }
+
+        var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
+
+        Assert.Equal(0, count);
+        Assert.Empty(_feedbackStore.GetRequestedItems(JellyfinUserId));
     }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryReconcileTests.cs
@@ -218,16 +218,18 @@ public sealed class SeerrDiscoveryReconcileTests : IDisposable
     public async Task Reconcile_NormalizesMediaTypeCasingAndUnknownValues()
     {
         RegisterUserResolution();
-        SeedCache(Rec(100, "  Movie "), Rec(200, "TV"));
-        // Seerr returns mixed-case and an unknown type that must collapse to movie.
-        RegisterRequestPage(RequestPageJson((100, "MOVIE"), (200, "Tv")));
+        SeedCache(Rec(100, "  Movie "), Rec(200, "TV"), Rec(300, "movie"));
+        // Mixed case resolves to its known type; an unknown value like "podcast" collapses to movie
+        // so it still matches the cached movie recommendation.
+        RegisterRequestPage(RequestPageJson((100, "MOVIE"), (200, "Tv"), (300, "podcast")));
 
         var count = await _sut.ReconcileRequestedItemsAsync(JellyfinUserId, CancellationToken.None);
 
-        Assert.Equal(2, count);
+        Assert.Equal(3, count);
         var requested = _feedbackStore.GetRequestedItems(JellyfinUserId);
         Assert.Contains((100, "movie"), requested);
         Assert.Contains((200, "tv"), requested);
+        Assert.Contains((300, "movie"), requested);
     }
 
     [Fact]

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryServiceHttpTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryServiceHttpTests.cs
@@ -961,6 +961,16 @@ internal sealed class ScriptedHttpHandler : HttpMessageHandler
     /// </summary>
     public int ThrowAfterCallIndex { get; set; }
 
+    /// <summary>
+    ///     Gets or sets a token source cancelled after <see cref="CancelAfterCallIndex"/> calls have been served, letting a test cancel the caller's token mid-pagination rather than before the first call.
+    /// </summary>
+    public CancellationTokenSource? CancelAfter { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the zero-based call index after which <see cref="CancelAfter"/> is cancelled.
+    /// </summary>
+    public int CancelAfterCallIndex { get; set; }
+
     private int _callCount;
 
     public void RegisterResponse(HttpMethod method, string pathSuffix, HttpStatusCode status, string body)
@@ -989,6 +999,13 @@ internal sealed class ScriptedHttpHandler : HttpMessageHandler
         }
 
         _callCount++;
+
+        // Cancel the caller's token once the requested number of calls have been served, so a test
+        // can drive a cancellation that lands between pagination iterations rather than up front.
+        if (CancelAfter is not null && _callCount > CancelAfterCallIndex)
+        {
+            CancelAfter.Cancel();
+        }
 
         if (request.Content is not null)
         {

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryServiceHttpTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryServiceHttpTests.cs
@@ -951,6 +951,18 @@ internal sealed class ScriptedHttpHandler : HttpMessageHandler
 
     public Exception? ThrowNext { get; set; }
 
+    /// <summary>
+    ///     Gets or sets an exception thrown once the handler has served <see cref="ThrowAfterCallIndex"/> calls. Lets a test allow the first N calls (e.g. user resolution) through and fail a later one (e.g. the request-page fetch).
+    /// </summary>
+    public Exception? ThrowAfter { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the zero-based call index at which <see cref="ThrowAfter"/> fires.
+    /// </summary>
+    public int ThrowAfterCallIndex { get; set; }
+
+    private int _callCount;
+
     public void RegisterResponse(HttpMethod method, string pathSuffix, HttpStatusCode status, string body)
     {
         _routes[(method, pathSuffix)] = (status, body);
@@ -968,6 +980,15 @@ internal sealed class ScriptedHttpHandler : HttpMessageHandler
             ThrowNext = null;
             throw toThrow;
         }
+
+        if (ThrowAfter is not null && _callCount >= ThrowAfterCallIndex)
+        {
+            var toThrow = ThrowAfter;
+            ThrowAfter = null;
+            throw toThrow;
+        }
+
+        _callCount++;
 
         if (request.Content is not null)
         {

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryServicePersistenceFailureTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryServicePersistenceFailureTests.cs
@@ -76,6 +76,7 @@ public sealed class SeerrDiscoveryServicePersistenceFailureTests : IDisposable
     public void Dispose()
     {
         _handler.Dispose();
+        _ensemble.Dispose();
         ControllerTestFactory.ResetPluginConfiguration();
     }
 

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryServicePersistenceFailureTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryServicePersistenceFailureTests.cs
@@ -140,8 +140,15 @@ public sealed class SeerrDiscoveryServicePersistenceFailureTests : IDisposable
             var second = NewProfile();
             _history.Setup(h => h.GetAllUserWatchProfiles()).Returns(Profiles(first, second));
 
-            // One-shot: fires on the first HTTP send (the first user's first genre query).
-            _handler.ThrowNext = new InvalidOperationException("unexpected");
+            // Out-of-band reconciliation resolves the Seerr user first; return an empty roster so
+            // reconciliation is a clean no-op and does not consume the one-shot exception below.
+            _handler.RegisterResponse(HttpMethod.Get, "/api/v1/user", HttpStatusCode.OK,
+                """{ "pageInfo": { "pages": 1, "pageSize": 50, "results": 0, "page": 1 }, "results": [] }""");
+
+            // Fire on the first user's first genre query (call index 1: the user fetch is index 0),
+            // an exception NOT in ExecuteDiscoverQuery's catch filter (InvalidOperationException).
+            _handler.ThrowAfter = new InvalidOperationException("unexpected");
+            _handler.ThrowAfterCallIndex = 1;
             RegisterMovieGenre(28, (2601, 8.0));
 
             var recorded = new List<Guid>();

--- a/Jellyfin.Plugin.JellyfinHelper/Api/UserDiscoveryController.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Api/UserDiscoveryController.cs
@@ -32,6 +32,11 @@ public sealed class UserDiscoveryController : ControllerBase
     private const string RadarrServiceType = "radarr";
     private static readonly TimeSpan RequestRateLimit = TimeSpan.FromSeconds(10);
 
+    /// <summary>
+    ///     Minimum interval between out-of-band request reconciliations for a single user on the view-load path. Matches the Seerr user-roster cache TTL, below which a re-fetch cannot surface fresher data.
+    /// </summary>
+    private static readonly TimeSpan ReconcileTtl = TimeSpan.FromMinutes(5);
+
     // Guards the rate-limit check-and-update so it is atomic. The controller is instantiated per request, so an instance lock would not serialize concurrent requests; a shared static lock does.
     private static readonly object RateLimitGate = new();
 
@@ -73,11 +78,12 @@ public sealed class UserDiscoveryController : ControllerBase
     /// <summary>
     ///     Returns the cached discovery recommendations for the currently authenticated user.
     /// </summary>
+    /// <param name="cancellationToken">Cancellation token for the reconciliation fetch.</param>
     /// <returns>The discovery result for the current user, or null if not available.</returns>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    public ActionResult<DiscoveryResult?> GetMyDiscoveryResults()
+    public async Task<ActionResult<DiscoveryResult?>> GetMyDiscoveryResults(CancellationToken cancellationToken)
     {
         if (!IsDiscoveryUserAccessEnabled())
         {
@@ -91,6 +97,11 @@ public sealed class UserDiscoveryController : ControllerBase
         }
 
         var currentUserId = userId.Value;
+
+        // Fold in any out-of-band Seerr requests before reading the pool so an item the user
+        // already requested elsewhere leaves the view and the next backfill item takes its slot.
+        await MaybeReconcileAsync(currentUserId, cancellationToken).ConfigureAwait(false);
+
         var results = _cache.Load();
         var userResult = results.FirstOrDefault(r => r.UserId.Equals(currentUserId));
         if (userResult == null)
@@ -119,6 +130,42 @@ public sealed class UserDiscoveryController : ControllerBase
             Recommendations = visible,
             GeneratedAt = userResult.GeneratedAt
         });
+    }
+
+    /// <summary>
+    ///     Runs discovery reconciliation for the user at most once per <see cref="ReconcileTtl"/> window. The reconciliation itself is fail-safe; this wrapper additionally guarantees a reconciliation failure never breaks the view render.
+    /// </summary>
+    /// <param name="userId">The current Jellyfin user id.</param>
+    /// <param name="cancellationToken">Cancellation token forwarded to the Seerr fetch.</param>
+    /// <returns>A task that completes once the (possibly skipped) reconciliation has finished.</returns>
+    private async Task MaybeReconcileAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        // Claim the per-user window under the shared lock BEFORE the async fetch so concurrent
+        // view loads for the same user do not each trigger a Seerr round-trip.
+        lock (RateLimitGate)
+        {
+            var key = BuildReconcileKey(userId);
+            if (_memoryCache.TryGetValue(key, out _))
+            {
+                return;
+            }
+
+            _memoryCache.Set(key, true, ReconcileTtl);
+        }
+
+        try
+        {
+            await _discovery.ReconcileRequestedItemsAsync(userId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Client disconnected mid-reconcile; nothing to render, propagation is harmless here
+            // but we swallow to keep the endpoint's contract (never fail on reconcile) uniform.
+        }
+        catch (Exception ex) when (!ex.IsFatal())
+        {
+            _logger.LogWarning(ex, "[Discovery] Reconciliation failed for user {UserId}; serving the cached view unchanged.", userId);
+        }
     }
 
     /// <summary>
@@ -555,6 +602,14 @@ public sealed class UserDiscoveryController : ControllerBase
     /// <returns>The fully-qualified, namespaced rate-limit cache key.</returns>
     internal static string BuildRateLimitKey(Guid jellyfinUserId) =>
         $"JellyfinHelper:discovery:ratelimit:{_rateLimitGeneration}:{jellyfinUserId:N}";
+
+    /// <summary>
+    ///     Builds the per-user reconciliation-throttle cache key. Shares the rate-limit generation counter so a plugin reload (via ClearRateLimitState) invalidates both throttles at once. The single source of truth for the key format, shared by the controller and its tests so the two can never drift.
+    /// </summary>
+    /// <param name="jellyfinUserId">The Jellyfin user the reconciliation belongs to.</param>
+    /// <returns>The fully-qualified, namespaced reconciliation-throttle cache key.</returns>
+    internal static string BuildReconcileKey(Guid jellyfinUserId) =>
+        $"JellyfinHelper:discovery:reconcile:{_rateLimitGeneration}:{jellyfinUserId:N}";
 
     /// <summary>
     ///     Reconstructs SeerrServiceInfo objects directly from the pre-evaluated AllowedQualityProfile list without requiring a second Seerr API call.

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/ISeerrDiscoveryService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/ISeerrDiscoveryService.cs
@@ -25,6 +25,14 @@ public interface ISeerrDiscoveryService
     Task GenerateDiscoveryRecommendationsAsync(CancellationToken cancellationToken);
 
     /// <summary>
+    ///     Reconciles a user's existing Seerr requests against their cached discovery recommendations. Items the user requested outside the discovery UI are recorded as a positive feedback signal and marked as requested in the cache so they leave the visible pool and the next backfill item takes their slot. Fail-safe: any Seerr error or an unresolvable user leaves the cache and feedback store untouched.
+    /// </summary>
+    /// <param name="jellyfinUserId">The Jellyfin user ID whose requests are reconciled.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of cached recommendations newly reconciled as requested.</returns>
+    Task<int> ReconcileRequestedItemsAsync(Guid jellyfinUserId, CancellationToken cancellationToken);
+
+    /// <summary>
     ///     Submits a media request to the configured Seerr instance.
     /// </summary>
     /// <param name="tmdbId">The TMDb ID of the media item.</param>

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/SeerrDiscoveryService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/SeerrDiscoveryService.cs
@@ -166,6 +166,16 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
         _logger = logger;
     }
 
+    /// <summary>
+    ///     Outcome of inspecting one reconcile request page: the scan is done, must keep paging, or hit an inconsistency that invalidates the whole snapshot.
+    /// </summary>
+    private enum ReconcilePageDecision
+    {
+        Continue,
+        Complete,
+        Incomplete,
+    }
+
     /// <inheritdoc />
     int ISeerrDiscoveryService.MaxVisiblePerUser => MaxVisiblePerUser;
 
@@ -351,8 +361,12 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
     {
         try
         {
-            _feedbackStore.RecordRequested(jellyfinUserId, tmdbId, mediaType);
+            // Stamp the cache first. A later feedback failure only means the item is not yet
+            // recorded as requested, so the next reconciliation retries it. The reverse order
+            // would put the key into GetRequestedItems while AlreadyRequested stayed false,
+            // and the retry would skip it, leaving the two stores permanently out of sync.
             await _cache.MarkAsRequestedAsync(tmdbId, mediaType, jellyfinUserId, CancellationToken.None).ConfigureAwait(false);
+            _feedbackStore.RecordRequested(jellyfinUserId, tmdbId, mediaType);
             return true;
         }
         catch (Exception ex) when (!ex.IsFatal())
@@ -403,51 +417,36 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var relPath = $"api/v1/request?take={ReconcilePageSize}&skip={skip}&sort=added&filter=all&requestedBy={seerrUserId}";
-                using var request = BuildRequest(HttpMethod.Get, baseUri, relPath, apiKey);
-                using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
-
-                if (!response.IsSuccessStatusCode)
+                var pageResult = await FetchRequestedPageAsync(
+                    client, baseUri, apiKey, seerrUserId, skip, cancellationToken).ConfigureAwait(false);
+                if (pageResult is null)
                 {
-                    _pluginLog.LogDebug(
-                        LogCategory,
-                        $"Reconcile: request page returned HTTP {(int)response.StatusCode} for Seerr user #{seerrUserId}.",
-                        _logger);
                     return null;
                 }
 
-                var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-                var pageResult = JsonSerializer.Deserialize<SeerrRequestPage>(json, JsonOptions);
-                var results = pageResult?.Results;
-                if (results == null || results.Count == 0)
-                {
-                    break;
-                }
-
-                foreach (var item in results)
-                {
-                    var media = item.Media;
-                    if (media != null && media.TmdbId > 0)
-                    {
-                        keys.Add((media.TmdbId, NormalizeReconcileMediaType(media.MediaType)));
-                    }
-                }
-
-                skip += ReconcilePageSize;
-                var totalResults = pageResult?.PageInfo?.Results ?? results.Count;
-                if (results.Count < ReconcilePageSize || skip >= totalResults)
+                var results = pageResult.Results;
+                if (results.Count == 0)
                 {
                     return keys;
                 }
 
-                if (page == ReconcileMaxPages - 1)
+                foreach (var key in results
+                    .Select(item => item.Media)
+                    .Where(media => media != null && media.TmdbId > 0)
+                    .Select(media => (media!.TmdbId, NormalizeReconcileMediaType(media.MediaType))))
                 {
-                    // Hit the page cap without exhausting the result set; the snapshot is incomplete.
-                    _pluginLog.LogWarning(
-                        LogCategory,
-                        $"Reconcile: request pagination hit the {ReconcileMaxPages}-page cap for Seerr user #{seerrUserId}; skipping to avoid acting on a partial snapshot.",
-                        null,
-                        _logger);
+                    keys.Add(key);
+                }
+
+                skip += ReconcilePageSize;
+                var pageDecision = DecideReconcilePagination(results.Count, skip, pageResult.PageInfo.Results, page, seerrUserId);
+                if (pageDecision == ReconcilePageDecision.Complete)
+                {
+                    return keys;
+                }
+
+                if (pageDecision == ReconcilePageDecision.Incomplete)
+                {
                     return null;
                 }
             }
@@ -467,6 +466,71 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
                 _logger);
             return null;
         }
+    }
+
+    /// <summary>
+    ///     Fetches and deserializes a single requestedBy-scoped request page. Returns null on any non-success status or unparseable body so the caller treats the whole snapshot as incomplete.
+    /// </summary>
+    private async Task<SeerrRequestPage?> FetchRequestedPageAsync(
+        HttpClient client,
+        Uri baseUri,
+        string apiKey,
+        int seerrUserId,
+        int skip,
+        CancellationToken cancellationToken)
+    {
+        var relPath = $"api/v1/request?take={ReconcilePageSize}&skip={skip}&sort=added&filter=all&requestedBy={seerrUserId}";
+        using var request = BuildRequest(HttpMethod.Get, baseUri, relPath, apiKey);
+        using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _pluginLog.LogDebug(
+                LogCategory,
+                $"Reconcile: request page returned HTTP {(int)response.StatusCode} for Seerr user #{seerrUserId}.",
+                _logger);
+            return null;
+        }
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        return JsonSerializer.Deserialize<SeerrRequestPage>(json, JsonOptions);
+    }
+
+    /// <summary>
+    ///     Decides whether pagination is done, must continue, or is inconsistent. A short page ends the scan. When the reported total is usable, exceeding it is an inconsistency the caller rejects; when the total is missing or zero we keep paging on a full page rather than trusting a bogus total and returning a truncated snapshot.
+    /// </summary>
+    private ReconcilePageDecision DecideReconcilePagination(int pageCount, int skip, int reportedTotal, int page, int seerrUserId)
+    {
+        if (pageCount < ReconcilePageSize)
+        {
+            return ReconcilePageDecision.Complete;
+        }
+
+        if (reportedTotal > 0)
+        {
+            if (skip == reportedTotal)
+            {
+                return ReconcilePageDecision.Complete;
+            }
+
+            if (skip > reportedTotal)
+            {
+                return ReconcilePageDecision.Incomplete;
+            }
+        }
+
+        if (page == ReconcileMaxPages - 1)
+        {
+            // Hit the page cap without exhausting the result set; the snapshot is incomplete.
+            _pluginLog.LogWarning(
+                LogCategory,
+                $"Reconcile: request pagination hit the {ReconcileMaxPages}-page cap for Seerr user #{seerrUserId}; skipping to avoid acting on a partial snapshot.",
+                null,
+                _logger);
+            return ReconcilePageDecision.Incomplete;
+        }
+
+        return ReconcilePageDecision.Continue;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/SeerrDiscoveryService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/SeerrDiscoveryService.cs
@@ -73,6 +73,16 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
     /// </summary>
     private const int ChildAccountMaxParentalRating = 60;
 
+    /// <summary>
+    ///     Page size for the requestedBy-scoped request enumeration used by reconciliation.
+    /// </summary>
+    private const int ReconcilePageSize = 50;
+
+    /// <summary>
+    ///     Safety cap on the number of request pages fetched during reconciliation to bound a single user's enumeration.
+    /// </summary>
+    private const int ReconcileMaxPages = 20;
+
     /// <summary>TMDb genre ID for Family content (movies and TV).</summary>
     private const int TmdbGenreFamily = 10751;
 
@@ -240,6 +250,237 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
         {
             PersistResultsAndRecordFeedback(allResults);
         }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> ReconcileRequestedItemsAsync(Guid jellyfinUserId, CancellationToken cancellationToken)
+    {
+        if (jellyfinUserId == Guid.Empty)
+        {
+            return 0;
+        }
+
+        var config = Plugin.Instance?.Configuration;
+        if (config == null
+            || string.IsNullOrWhiteSpace(config.SeerrUrl)
+            || string.IsNullOrWhiteSpace(config.SeerrApiKey))
+        {
+            return 0;
+        }
+
+        var seerrUserId = await ResolveSeerrUserIdAsync(jellyfinUserId, cancellationToken).ConfigureAwait(false);
+        if (seerrUserId is not > 0)
+        {
+            return 0;
+        }
+
+        var requestedKeys = await FetchRequestedKeysForSeerrUserAsync(
+            config, seerrUserId.Value, cancellationToken).ConfigureAwait(false);
+        if (requestedKeys is null || requestedKeys.Count == 0)
+        {
+            return 0;
+        }
+
+        return await ApplyReconciliationAsync(jellyfinUserId, requestedKeys).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Records the intersection of a user's Seerr-requested keys with their cached recommendations as a positive feedback signal and marks each match as requested in the cache. Items already recorded as requested are skipped so repeated reconciliation does not rewrite the feedback file.
+    /// </summary>
+    /// <param name="jellyfinUserId">The Jellyfin user whose cache and feedback are updated.</param>
+    /// <param name="requestedKeys">The user's requested (TmdbId, MediaType) keys fetched from Seerr.</param>
+    /// <returns>The number of cached recommendations newly reconciled.</returns>
+    private async Task<int> ApplyReconciliationAsync(
+        Guid jellyfinUserId,
+        HashSet<(int TmdbId, string MediaType)> requestedKeys)
+    {
+        var userResult = _cache.Load().FirstOrDefault(r => r.UserId.Equals(jellyfinUserId));
+        if (userResult == null || userResult.Recommendations.Count == 0)
+        {
+            return 0;
+        }
+
+        HashSet<(int TmdbId, string MediaType)> alreadyRecorded;
+        try
+        {
+            alreadyRecorded = new HashSet<(int, string)>(_feedbackStore.GetRequestedItems(jellyfinUserId));
+        }
+        catch (Exception ex) when (!ex.IsFatal())
+        {
+            _pluginLog.LogDebug(
+                LogCategory,
+                $"Reconcile: could not load already-requested items for user {jellyfinUserId}: {ex.Message}",
+                _logger);
+            alreadyRecorded = [];
+        }
+
+        var reconciled = 0;
+        foreach (var rec in userResult.Recommendations)
+        {
+            (int TmdbId, string MediaType) key = (rec.TmdbId, NormalizeReconcileMediaType(rec.MediaType));
+            if (rec.TmdbId <= 0 || alreadyRecorded.Contains(key) || !requestedKeys.Contains(key))
+            {
+                continue;
+            }
+
+            if (await ReconcileSingleItemAsync(jellyfinUserId, key.TmdbId, key.MediaType).ConfigureAwait(false))
+            {
+                reconciled++;
+            }
+        }
+
+        if (reconciled > 0)
+        {
+            _pluginLog.LogInfo(
+                LogCategory,
+                $"Reconciled {reconciled} out-of-band Seerr request(s) into discovery for user {jellyfinUserId}.",
+                _logger);
+        }
+
+        return reconciled;
+    }
+
+    /// <summary>
+    ///     Records a single reconciled item as requested and marks it in the cache. Side effects use CancellationToken.None so a disconnected caller cannot leave the feedback and cache stores inconsistent.
+    /// </summary>
+    /// <param name="jellyfinUserId">The owning Jellyfin user.</param>
+    /// <param name="tmdbId">The TMDb ID of the item.</param>
+    /// <param name="mediaType">The normalized media type.</param>
+    /// <returns><see langword="true"/> when the item was recorded without a fatal failure.</returns>
+    private async Task<bool> ReconcileSingleItemAsync(Guid jellyfinUserId, int tmdbId, string mediaType)
+    {
+        try
+        {
+            _feedbackStore.RecordRequested(jellyfinUserId, tmdbId, mediaType);
+            await _cache.MarkAsRequestedAsync(tmdbId, mediaType, jellyfinUserId, CancellationToken.None).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex) when (!ex.IsFatal())
+        {
+            _pluginLog.LogDebug(
+                LogCategory,
+                $"Reconcile: failed to record requested item {mediaType}#{tmdbId} for user {jellyfinUserId}: {ex.Message}",
+                _logger);
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///     Fetches the set of (TmdbId, MediaType) keys the given Seerr user has requested, paginating the requestedBy-scoped request endpoint. Returns null on any failure or incomplete fetch so callers treat a partial snapshot as "do nothing" rather than acting on truncated data.
+    /// </summary>
+    /// <param name="config">The plugin configuration providing the Seerr endpoint and key.</param>
+    /// <param name="seerrUserId">The resolved Seerr user ID to scope the query to.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The requested keys, or null when the fetch could not complete.</returns>
+    private async Task<HashSet<(int TmdbId, string MediaType)>?> FetchRequestedKeysForSeerrUserAsync(
+        PluginConfiguration config,
+        int seerrUserId,
+        CancellationToken cancellationToken)
+    {
+        Uri baseUri;
+        string apiKey;
+        try
+        {
+            (baseUri, apiKey) = ValidateSeerrConfig(config.SeerrUrl, config.SeerrApiKey);
+        }
+        catch (Exception ex) when (ex is UriFormatException or ArgumentException)
+        {
+            _pluginLog.LogWarning(
+                LogCategory,
+                $"Reconcile: invalid Seerr configuration: {ex.Message}",
+                ex,
+                _logger);
+            return null;
+        }
+
+        var client = GetSeerrClient();
+        var keys = new HashSet<(int TmdbId, string MediaType)>();
+        var skip = 0;
+
+        try
+        {
+            for (var page = 0; page < ReconcileMaxPages; page++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var relPath = $"api/v1/request?take={ReconcilePageSize}&skip={skip}&sort=added&filter=all&requestedBy={seerrUserId}";
+                using var request = BuildRequest(HttpMethod.Get, baseUri, relPath, apiKey);
+                using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _pluginLog.LogDebug(
+                        LogCategory,
+                        $"Reconcile: request page returned HTTP {(int)response.StatusCode} for Seerr user #{seerrUserId}.",
+                        _logger);
+                    return null;
+                }
+
+                var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                var pageResult = JsonSerializer.Deserialize<SeerrRequestPage>(json, JsonOptions);
+                var results = pageResult?.Results;
+                if (results == null || results.Count == 0)
+                {
+                    break;
+                }
+
+                foreach (var item in results)
+                {
+                    var media = item.Media;
+                    if (media != null && media.TmdbId > 0)
+                    {
+                        keys.Add((media.TmdbId, NormalizeReconcileMediaType(media.MediaType)));
+                    }
+                }
+
+                skip += ReconcilePageSize;
+                var totalResults = pageResult?.PageInfo?.Results ?? results.Count;
+                if (results.Count < ReconcilePageSize || skip >= totalResults)
+                {
+                    return keys;
+                }
+
+                if (page == ReconcileMaxPages - 1)
+                {
+                    // Hit the page cap without exhausting the result set; the snapshot is incomplete.
+                    _pluginLog.LogWarning(
+                        LogCategory,
+                        $"Reconcile: request pagination hit the {ReconcileMaxPages}-page cap for Seerr user #{seerrUserId}; skipping to avoid acting on a partial snapshot.",
+                        null,
+                        _logger);
+                    return null;
+                }
+            }
+
+            return keys;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or TimeoutException or JsonException)
+        {
+            _pluginLog.LogWarning(
+                LogCategory,
+                $"Reconcile: failed to fetch requests for Seerr user #{seerrUserId}: {ex.Message}",
+                ex,
+                _logger);
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     Normalizes a media type to the lowercase "movie"/"tv" form used as the composite key across the feedback store and cache. Unknown or empty values collapse to "movie" to match DiscoveryFeedbackStore.
+    /// </summary>
+    private static string NormalizeReconcileMediaType(string? mediaType)
+    {
+        if (string.IsNullOrWhiteSpace(mediaType))
+        {
+            return MediaTypeMovie;
+        }
+
+        var normalized = mediaType.Trim().ToLowerInvariant();
+        return normalized == "tv" ? "tv" : MediaTypeMovie;
     }
 
     /// <summary>
@@ -1195,6 +1436,9 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
         IReadOnlyDictionary<Guid, int> seriesEpisodeCounts,
         CancellationToken cancellationToken)
     {
+        // Fold in any requests the user made outside discovery before building the exclusion set, so the fresh signal both excludes those items from this run and reaches training.
+        await ReconcileRequestedItemsAsync(profile.UserId, cancellationToken).ConfigureAwait(false);
+
         var genrePreferences = PreferenceBuilder.BuildGenrePreferenceVector(profile, seriesEpisodeCounts);
         if (genrePreferences.Count == 0)
         {

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/SeerrDiscoveryService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/SeerrDiscoveryService.cs
@@ -408,50 +408,10 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
         }
 
         var client = GetSeerrClient();
-        var keys = new HashSet<(int TmdbId, string MediaType)>();
-        var skip = 0;
 
         try
         {
-            for (var page = 0; page < ReconcileMaxPages; page++)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var pageResult = await FetchRequestedPageAsync(
-                    client, baseUri, apiKey, seerrUserId, skip, cancellationToken).ConfigureAwait(false);
-                if (pageResult is null)
-                {
-                    return null;
-                }
-
-                var results = pageResult.Results;
-                if (results.Count == 0)
-                {
-                    return keys;
-                }
-
-                foreach (var key in results
-                    .Select(item => item.Media)
-                    .Where(media => media != null && media.TmdbId > 0)
-                    .Select(media => (media!.TmdbId, NormalizeReconcileMediaType(media.MediaType))))
-                {
-                    keys.Add(key);
-                }
-
-                skip += ReconcilePageSize;
-                var pageDecision = DecideReconcilePagination(results.Count, skip, pageResult.PageInfo.Results, page, seerrUserId);
-                if (pageDecision == ReconcilePageDecision.Complete)
-                {
-                    return keys;
-                }
-
-                if (pageDecision == ReconcilePageDecision.Incomplete)
-                {
-                    return null;
-                }
-            }
-
-            return keys;
+            return await AccumulateRequestedKeysAsync(client, baseUri, apiKey, seerrUserId, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -465,6 +425,68 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
                 ex,
                 _logger);
             return null;
+        }
+    }
+
+    /// <summary>
+    ///     Pages through the requestedBy-scoped request endpoint, accumulating (TmdbId, MediaType) keys until the scan completes. Returns null when a page fetch fails or pagination metadata is inconsistent so the caller treats a partial snapshot as "do nothing".
+    /// </summary>
+    private async Task<HashSet<(int TmdbId, string MediaType)>?> AccumulateRequestedKeysAsync(
+        HttpClient client,
+        Uri baseUri,
+        string apiKey,
+        int seerrUserId,
+        CancellationToken cancellationToken)
+    {
+        var keys = new HashSet<(int TmdbId, string MediaType)>();
+        var skip = 0;
+
+        for (var page = 0; page < ReconcileMaxPages; page++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var pageResult = await FetchRequestedPageAsync(
+                client, baseUri, apiKey, seerrUserId, skip, cancellationToken).ConfigureAwait(false);
+            if (pageResult is null)
+            {
+                return null;
+            }
+
+            var results = pageResult.Results;
+            if (results.Count == 0)
+            {
+                return keys;
+            }
+
+            AddRequestedKeys(keys, results);
+
+            skip += ReconcilePageSize;
+            var pageDecision = DecideReconcilePagination(results.Count, skip, pageResult.PageInfo.Results, page, seerrUserId);
+            if (pageDecision == ReconcilePageDecision.Complete)
+            {
+                return keys;
+            }
+
+            if (pageDecision == ReconcilePageDecision.Incomplete)
+            {
+                return null;
+            }
+        }
+
+        return keys;
+    }
+
+    /// <summary>
+    ///     Adds the normalized (TmdbId, MediaType) key of each row with usable media to the accumulator.
+    /// </summary>
+    private static void AddRequestedKeys(HashSet<(int TmdbId, string MediaType)> keys, List<SeerrRequest> results)
+    {
+        foreach (var key in results
+            .Select(item => item.Media)
+            .Where(media => media != null && media.TmdbId > 0)
+            .Select(media => (media!.TmdbId, NormalizeReconcileMediaType(media.MediaType))))
+        {
+            keys.Add(key);
         }
     }
 

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/SeerrDiscoveryService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/SeerrDiscoveryService.cs
@@ -361,12 +361,12 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
     {
         try
         {
-            // Stamp the cache first. A later feedback failure only means the item is not yet
-            // recorded as requested, so the next reconciliation retries it. The reverse order
-            // would put the key into GetRequestedItems while AlreadyRequested stayed false,
-            // and the retry would skip it, leaving the two stores permanently out of sync.
-            await _cache.MarkAsRequestedAsync(tmdbId, mediaType, jellyfinUserId, CancellationToken.None).ConfigureAwait(false);
+            // Record the durable feedback signal before touching the cache. The training signal is
+            // the point of reconciliation, and GetRequestedItems reads only the feedback store, so a
+            // later cache failure still leaves the item excluded from the view and from regeneration.
+            // The reverse order would risk stamping the cache while the durable signal is lost.
             _feedbackStore.RecordRequested(jellyfinUserId, tmdbId, mediaType);
+            await _cache.MarkAsRequestedAsync(tmdbId, mediaType, jellyfinUserId, CancellationToken.None).ConfigureAwait(false);
             return true;
         }
         catch (Exception ex) when (!ex.IsFatal())

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A [Jellyfin](https://jellyfin.org/) plugin that provides automated cleanup tasks
 
 [![Quality gate](https://img.shields.io/sonar/quality_gate/JellyPlugins_jellyfin-helper?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&logo=sonarcloud&logoColor=white&labelColor=2d333b)](https://sonarcloud.io/summary/new_code?id=JellyPlugins_jellyfin-helper)<br>
 [![codecov](https://img.shields.io/codecov/c/github/JellyPlugins/jellyfin-helper?style=flat-square&logo=codecov&logoColor=white&labelColor=2d333b)](https://codecov.io/gh/JellyPlugins/jellyfin-helper)<br>
-[![Tests](https://img.shields.io/badge/unit%20tests-5170-2ea043?style=flat-square&logo=checkmarx&logoColor=white&labelColor=2d333b)](Jellyfin.Plugin.JellyfinHelper.Tests/)<br>
+[![Tests](https://img.shields.io/badge/unit%20tests-5193-2ea043?style=flat-square&logo=checkmarx&logoColor=white&labelColor=2d333b)](Jellyfin.Plugin.JellyfinHelper.Tests/)<br>
 [![E2E](https://img.shields.io/badge/e2e%20tests-294-2ea043?style=flat-square&logo=docker&logoColor=white&labelColor=2d333b)](test/e2e/)
 
 </td>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A [Jellyfin](https://jellyfin.org/) plugin that provides automated cleanup tasks
 
 [![Quality gate](https://img.shields.io/sonar/quality_gate/JellyPlugins_jellyfin-helper?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&logo=sonarcloud&logoColor=white&labelColor=2d333b)](https://sonarcloud.io/summary/new_code?id=JellyPlugins_jellyfin-helper)<br>
 [![codecov](https://img.shields.io/codecov/c/github/JellyPlugins/jellyfin-helper?style=flat-square&logo=codecov&logoColor=white&labelColor=2d333b)](https://codecov.io/gh/JellyPlugins/jellyfin-helper)<br>
-[![Tests](https://img.shields.io/badge/unit%20tests-5193-2ea043?style=flat-square&logo=checkmarx&logoColor=white&labelColor=2d333b)](Jellyfin.Plugin.JellyfinHelper.Tests/)<br>
+[![Tests](https://img.shields.io/badge/unit%20tests-5196-2ea043?style=flat-square&logo=checkmarx&logoColor=white&labelColor=2d333b)](Jellyfin.Plugin.JellyfinHelper.Tests/)<br>
 [![E2E](https://img.shields.io/badge/e2e%20tests-294-2ea043?style=flat-square&logo=docker&logoColor=white&labelColor=2d333b)](test/e2e/)
 
 </td>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A [Jellyfin](https://jellyfin.org/) plugin that provides automated cleanup tasks
 
 [![Quality gate](https://img.shields.io/sonar/quality_gate/JellyPlugins_jellyfin-helper?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&logo=sonarcloud&logoColor=white&labelColor=2d333b)](https://sonarcloud.io/summary/new_code?id=JellyPlugins_jellyfin-helper)<br>
 [![codecov](https://img.shields.io/codecov/c/github/JellyPlugins/jellyfin-helper?style=flat-square&logo=codecov&logoColor=white&labelColor=2d333b)](https://codecov.io/gh/JellyPlugins/jellyfin-helper)<br>
-[![Tests](https://img.shields.io/badge/unit%20tests-5196-2ea043?style=flat-square&logo=checkmarx&logoColor=white&labelColor=2d333b)](Jellyfin.Plugin.JellyfinHelper.Tests/)<br>
+[![Tests](https://img.shields.io/badge/unit%20tests-5203-2ea043?style=flat-square&logo=checkmarx&logoColor=white&labelColor=2d333b)](Jellyfin.Plugin.JellyfinHelper.Tests/)<br>
 [![E2E](https://img.shields.io/badge/e2e%20tests-294-2ea043?style=flat-square&logo=docker&logoColor=white&labelColor=2d333b)](test/e2e/)
 
 </td>

--- a/test/e2e/mocks/seerr-server.js
+++ b/test/e2e/mocks/seerr-server.js
@@ -169,6 +169,19 @@ const server = http.createServer(async (req, res) => {
     if (body.permissions !== undefined) users[1].permissions = Number(body.permissions);
     send(res, 200, { ok: true }); return done(200);
   }
+  // Append an out-of-band request attributed to a Seerr user so the plugin's discovery
+  // reconciliation can detect it via GET /api/v1/request?requestedBy={id}.
+  if (path === '/seed-user-request' && method === 'POST') {
+    const body = JSON.parse((await readBody(req)) || '{}');
+    requests.push({
+      id: Number(body.id ?? Date.now()),
+      createdAt: new Date().toISOString(),
+      status: 2,
+      media: { mediaType: String(body.mediaType ?? 'movie'), tmdbId: Number(body.tmdbId), status: 3 },
+      requestedBy: { id: Number(body.requestedBy) },
+    });
+    send(res, 200, { ok: true }); return done(200);
+  }
 
   if (!apiKey) { send(res, 401, { error: 'missing X-Api-Key' }); return done(401); }
   // A literal mask value is never a real key.
@@ -216,9 +229,15 @@ const server = http.createServer(async (req, res) => {
       send(res, 500, { error: 'forced page failure' });
       return done(500);
     }
-    const slice = requests.slice(skip, skip + take);
+    // Scope by requestedBy when the plugin's reconciliation asks for a single user's requests.
+    const requestedByRaw = url.searchParams.get('requestedBy');
+    const requestedBy = requestedByRaw === null ? null : Number(requestedByRaw);
+    const scoped = requestedBy === null
+      ? requests
+      : requests.filter((r) => r.requestedBy?.id === requestedBy);
+    const slice = scoped.slice(skip, skip + take);
     // Inflate the total so the plugin's hasMore (skip < results) requests page 2.
-    const totalResults = inflateResults ? Math.max(requests.length, take + 1) : requests.length;
+    const totalResults = inflateResults ? Math.max(scoped.length, take + 1) : scoped.length;
     listCalls.push({ skip, status: 200 });
     send(res, 200, {
       pageInfo: { page: (skip / take) + 1, pages: inflateResults ? 2 : 1, results: totalResults, pageSize: take },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Discovery results now reconcile requests made directly in Seerr.
  - Reconciled recommendations are marked as requested and replaced with the next available items.
  - Reconciliation is throttled and fails safely without interrupting result loading.

- **Tests**
  - Added comprehensive coverage for reconciliation, pagination, errors, cancellation, media types, and user resolution.
  - Updated end-to-end test mocks and asynchronous controller tests.

- **Documentation**
  - Updated contributor guidance and documented unit test counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->