### PR TITLE
Fix known issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ test suite that runs the plugin inside a real Jellyfin server on every change.
 
 ### Breaking
 - **Requires Jellyfin 12.0+.** v3.x will not install on Jellyfin 10.x. If you're still on 10.x, stay on v2.1.0.6 (served from the same plugin repository).
-- **Recommendations retrain from scratch.** The recommendation model is a new, much larger design, so any model your server had already trained is discarded on upgrade and rebuilt automatically over the next scheduled runs. Your suggestions settle back in after the plugin has seen your library again.
+- **Recommendations retrain from scratch.** The recommendation model is a new, much larger design, so any model your server had already trained is discarded on upgrade and rebuilt automatically over the next scheduled runs. Your suggestions settle back in after the plugin has seen your library again. Technically the candidate vector grows to 38 features and the persisted weight schema version moves from 2 to 3, so existing `ml_weights.json`, `neural_weights.json` and `ensemble_state.json` are treated as incompatible and rebuilt.
 - **A few API responses changed** (only relevant if you script against the plugin). Saving configuration now uses `PUT` instead of `POST`; the log level is set through its own endpoint rather than the settings save; and several endpoints return clearer status codes (a submitted request now reports "created", clearing logs reports "no content", a failed integration test reports a gateway error instead of a fake success, and the user-activity endpoints report "unavailable" until the scheduled task has built their data). The growth-timeline export field `totalFilesScanned` is now `totalDirectoriesScanned`.
 
 ### Added
@@ -50,7 +50,7 @@ test suite that runs the plugin inside a real Jellyfin server on every change.
 
 ### Tests
 - **New end-to-end test suite.** Alongside the unit tests, the plugin now runs inside a real Jellyfin 12 server (in a throwaway container, with stand-in Radarr/Sonarr/Jellyseerr services) and is exercised the way a real user would: changing settings, running each cleanup mode, importing/exporting a backup, and clicking through every dashboard tab. It also deliberately throws bad and hostile input at the plugin and uses "canary" files to prove that cleanup never deletes or touches anything outside your libraries, and that every admin-only action stays locked to admins. **296 tests across 46 files**, running automatically on every change plus a nightly full run.
-- **Unit tests: 5311 total** (+2986 vs. v2.1.0.6), including full coverage of the typed API responses.
+- **Unit tests: 5336 total** Including full coverage of the typed API responses.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,7 @@ Tests mirror the source structure:
 Jellyfin.Plugin.JellyfinHelper.Tests/
 ├── PluginServiceRegistratorTests.cs      # DI-container smoke test: every registered service must resolve
 ├── PluginTests.cs                        # Bootstrap: Instance publishing, GetPages, UpdateIndexHtml idempotency, OnUninstalling cleanup guards
+├── PluginResolveRealPathTests.cs         # Bounded symlink resolution: plain path, single link, cycle terminates, max-hops cap, IOException propagates (fail-closed)
 ├── Api/                           # Controller tests
 │   ├── ArrIntegrationControllerTests.cs
 │   ├── ArrIntegrationControllerExtendedTests.cs      # Index bounds, 502 with named instance, trash exclusion, partial-config 400 contract
@@ -632,6 +633,7 @@ are intentionally excluded. When you add a file, add a line for it here.
 - `ContributingDocCoverageTests.cs` - Drift guard: every tracked source/test file must be listed in this index
 - `PluginServiceRegistratorTests.cs`
 - `PluginTests.cs`
+- `PluginResolveRealPathTests.cs`
 
 `Jellyfin.Plugin.JellyfinHelper.Tests/Api/`
 

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Api/DiscoveryControllerExtendedTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Api/DiscoveryControllerExtendedTests.cs
@@ -314,7 +314,7 @@ public sealed class DiscoveryControllerExtendedTests : IDisposable
     }
 
     [Fact]
-    public void GetDiscoveryResults_FiltersDismissedItems()
+    public async Task GetDiscoveryResults_FiltersDismissedItems()
     {
         var userId = Guid.NewGuid();
         var dismissedTmdbId = 999;
@@ -339,7 +339,7 @@ public sealed class DiscoveryControllerExtendedTests : IDisposable
         _cache.Save(results);
 
         var controller = CreateController();
-        var response = controller.GetDiscoveryResults();
+        var response = await controller.GetDiscoveryResults();
 
         var ok = Assert.IsType<OkObjectResult>(response.Result);
         var filtered = Assert.IsAssignableFrom<IReadOnlyList<DiscoveryResult>>(ok.Value);
@@ -349,7 +349,7 @@ public sealed class DiscoveryControllerExtendedTests : IDisposable
     }
 
     [Fact]
-    public void GetDiscoveryResults_FiltersRequestedItems()
+    public async Task GetDiscoveryResults_FiltersRequestedItems()
     {
         var userId = Guid.NewGuid();
         var requestedTmdbId = 555;
@@ -374,7 +374,7 @@ public sealed class DiscoveryControllerExtendedTests : IDisposable
         _cache.Save(results);
 
         var controller = CreateController();
-        var response = controller.GetDiscoveryResults();
+        var response = await controller.GetDiscoveryResults();
 
         var ok = Assert.IsType<OkObjectResult>(response.Result);
         var filtered = Assert.IsAssignableFrom<IReadOnlyList<DiscoveryResult>>(ok.Value);
@@ -384,7 +384,7 @@ public sealed class DiscoveryControllerExtendedTests : IDisposable
     }
 
     [Fact]
-    public void GetDiscoveryResults_FiltersAlreadyRequestedFlag()
+    public async Task GetDiscoveryResults_FiltersAlreadyRequestedFlag()
     {
         var userId = Guid.NewGuid();
         _feedbackStoreMock.Setup(s => s.GetDismissedItems(userId))
@@ -408,7 +408,7 @@ public sealed class DiscoveryControllerExtendedTests : IDisposable
         _cache.Save(results);
 
         var controller = CreateController();
-        var response = controller.GetDiscoveryResults();
+        var response = await controller.GetDiscoveryResults();
 
         var ok = Assert.IsType<OkObjectResult>(response.Result);
         var filtered = Assert.IsAssignableFrom<IReadOnlyList<DiscoveryResult>>(ok.Value);
@@ -418,7 +418,7 @@ public sealed class DiscoveryControllerExtendedTests : IDisposable
     }
 
     [Fact]
-    public void GetDiscoveryResults_FeedbackStoreThrows_StillReturnsOk()
+    public async Task GetDiscoveryResults_FeedbackStoreThrows_StillReturnsOk()
     {
         var userId = Guid.NewGuid();
         _feedbackStoreMock.Setup(s => s.GetDismissedItems(userId))
@@ -439,7 +439,7 @@ public sealed class DiscoveryControllerExtendedTests : IDisposable
         _cache.Save(results);
 
         var controller = CreateController();
-        var response = controller.GetDiscoveryResults();
+        var response = await controller.GetDiscoveryResults();
 
         var ok = Assert.IsType<OkObjectResult>(response.Result);
         var filtered = Assert.IsAssignableFrom<IReadOnlyList<DiscoveryResult>>(ok.Value);
@@ -448,7 +448,7 @@ public sealed class DiscoveryControllerExtendedTests : IDisposable
     }
 
     [Fact]
-    public void GetDiscoveryResults_TakesOnlyMaxVisiblePerUser()
+    public async Task GetDiscoveryResults_TakesOnlyMaxVisiblePerUser()
     {
         var userId = Guid.NewGuid();
         _feedbackStoreMock.Setup(s => s.GetDismissedItems(userId))
@@ -465,7 +465,7 @@ public sealed class DiscoveryControllerExtendedTests : IDisposable
         _cache.Save([new DiscoveryResult { UserId = userId, UserName = "u", Recommendations = recs }]);
 
         var controller = CreateController();
-        var response = controller.GetDiscoveryResults();
+        var response = await controller.GetDiscoveryResults();
 
         var ok = Assert.IsType<OkObjectResult>(response.Result);
         var filtered = Assert.IsAssignableFrom<IReadOnlyList<DiscoveryResult>>(ok.Value);

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Api/DiscoveryControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Api/DiscoveryControllerTests.cs
@@ -58,10 +58,10 @@ public class DiscoveryControllerTests : IDisposable
     }
 
     [Fact]
-    public void Get_ReturnsOkWithResults()
+    public async Task Get_ReturnsOkWithResults()
     {
         var controller = CreateController();
-        var result = controller.GetDiscoveryResults();
+        var result = await controller.GetDiscoveryResults();
         Assert.IsType<OkObjectResult>(result.Result);
     }
 

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Api/ModelBindingLogFilterTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Api/ModelBindingLogFilterTests.cs
@@ -152,13 +152,13 @@ public class ModelBindingLogFilterTests
     }
 
     /// <summary>
-    ///     Contract test: the filter MUST have MinValue as its execution order so it runs before [ApiController]'s built-in ModelStateInvalidFilter (which uses Order = int.MinValue + 100).
+    ///     Contract test: the filter must order below the built-in ModelStateInvalidFilter (which runs at -2000) so it fires first and can log the binding failure before the automatic 400 is written.
     /// </summary>
     [Fact]
-    public void Order_IsMinValue_SoRunsBeforeApiControllerAuto400()
+    public void Order_RunsBeforeApiControllerAuto400()
     {
         var filter = CreateFilter();
-        Assert.Equal(int.MinValue, filter.Order);
+        Assert.True(filter.Order < -2000, $"Filter order {filter.Order} must be below the built-in ModelStateInvalidFilter order of -2000.");
     }
 
     // Branch-coverage tests for the error-string composition helpers on the ModelState path. The `bindingErrors` join produces different strings depending on which of the three fallback branches inside the SelectMany-Select projection fires: 1.

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginResolveRealPathTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginResolveRealPathTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinHelper.Tests;
+
+/// <summary>
+///     Tests for <see cref="Plugin.ResolveRealPathCore(string, Func{string, string?})"/> - the bounded
+///     symlink-resolution helper used to canonicalize the File Transformation assembly location before
+///     the plugins-directory origin check. Covers plain paths, single links, cycle termination, and the
+///     max-hops cap using an injectable resolver so the bounded traversal is exercised without real symlinks.
+/// </summary>
+public sealed class PluginResolveRealPathTests
+{
+    private static readonly StringComparer PathComparer =
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+    private static string Rooted(params string[] segments)
+    {
+        var root = OperatingSystem.IsWindows() ? "C:\\" : "/";
+        return Path.GetFullPath(Path.Combine(root, Path.Combine(segments)));
+    }
+
+    [Fact]
+    public void ResolveRealPathCore_PlainPath_ReturnsNormalizedPath()
+    {
+        var input = Rooted("media", "movies", "file.mkv");
+
+        // No component is a link, so nothing is followed.
+        var result = Plugin.ResolveRealPathCore(input, _ => null);
+
+        Assert.Equal(input, result, PathComparer);
+    }
+
+    [Fact]
+    public void ResolveRealPathCore_SingleSymlink_ResolvesToTarget()
+    {
+        var link = Rooted("links", "movies");
+        var target = Rooted("real", "movies");
+
+        var result = Plugin.ResolveRealPathCore(
+            link,
+            candidate => PathComparer.Equals(candidate, link) ? target : null);
+
+        Assert.Equal(target, result, PathComparer);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task SymlinkCycle_TerminatesWithoutThrowing()
+    {
+        var a = Rooted("cycle", "a");
+        var b = Rooted("cycle", "b");
+
+        string Resolver(string candidate)
+        {
+            if (PathComparer.Equals(candidate, a))
+            {
+                return b;
+            }
+
+            if (PathComparer.Equals(candidate, b))
+            {
+                return a;
+            }
+
+            return null!;
+        }
+
+        // A short timeout guards against a regression that reintroduces unbounded recursion.
+        string? result = null;
+        var task = System.Threading.Tasks.Task.Run(() => result = Plugin.ResolveRealPathCore(a, Resolver));
+
+        try
+        {
+            await task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.NotNull(result);
+        }
+        catch (OperationCanceledException)
+        {
+            Assert.Fail("Resolution of a symlink cycle did not terminate.");
+        }
+
+        // The last resolved candidate is one of the two cycle nodes; the important guarantee is that
+        // it returns a value rather than throwing or hanging.
+        Assert.True(
+            PathComparer.Equals(result, a) || PathComparer.Equals(result, b),
+            $"Unexpected terminal path '{result}'.");
+    }
+
+    [Fact]
+    public void ResolveRealPathCore_ExceedingMaxHops_StopsAtCap()
+    {
+        // A chain that always points one component deeper never cycles, so only the hop cap can stop it.
+        var visitedCandidates = new List<string>();
+        var start = Rooted("chain", "start");
+
+        string? Resolver(string candidate)
+        {
+            // Only the leaf chain follows links; ancestors resolve to themselves so the count reflects
+            // the bounded leaf traversal alone.
+            if (!candidate.StartsWith(start, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            visitedCandidates.Add(candidate);
+            return candidate + "x";
+        }
+
+        var result = Plugin.ResolveRealPathCore(start, Resolver);
+
+        Assert.NotNull(result);
+
+        // The traversal follows at most MaxLinkHops links before returning, so the number of link
+        // components it resolves cannot exceed the cap by more than one (the final candidate that
+        // triggers the stop).
+        Assert.True(
+            visitedCandidates.Count <= Plugin.MaxLinkHops + 1,
+            $"Followed {visitedCandidates.Count} links, expected at most {Plugin.MaxLinkHops + 1}.");
+    }
+
+    [Fact]
+    public void ResolveRealPathCore_IOExceptionFromResolver_Propagates()
+    {
+        // An OS ELOOP surfaces as IOException from ResolveLinkTarget; the helper must not swallow it so
+        // the caller can fail closed.
+        var start = Rooted("loop", "node");
+
+        Assert.Throws<IOException>(() =>
+            Plugin.ResolveRealPathCore(start, _ => throw new IOException("ELOOP")));
+    }
+
+    [Fact]
+    public void ResolveRealPath_RealSymlinkChain_ResolvesToFinalTarget()
+    {
+        // Creating symlinks on Windows typically needs elevation or developer mode; skip there when it
+        // is not permitted and rely on the injectable-resolver tests for the bounded traversal logic.
+        var tempRoot = Path.Combine(Path.GetTempPath(), "JhResolveRealPath_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            var targetDir = Path.Combine(tempRoot, "real");
+            Directory.CreateDirectory(targetDir);
+            var linkPath = Path.Combine(tempRoot, "link");
+
+            try
+            {
+                Directory.CreateSymbolicLink(linkPath, targetDir);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Symlink creation requires elevated privileges on some Windows configurations, and
+                // xUnit 2.x has no Assert.Skip. Returning early keeps the test green but un-asserted,
+                // which is acceptable because the bounded-traversal logic is fully covered by the
+                // injectable-resolver tests above; this test only adds coverage where symlinks work.
+                return;
+            }
+
+            var result = Plugin.ResolveRealPathCore(linkPath, Plugin.RealLeafResolver);
+
+            Assert.Equal(Path.GetFullPath(targetDir), result, PathComparer);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/LibraryPathResolverAllowedRootTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/LibraryPathResolverAllowedRootTests.cs
@@ -215,4 +215,73 @@ public sealed class LibraryPathResolverAllowedRootTests
 
         Assert.Equal(["/media/movies"], scope.AllowedRoots);
     }
+
+    [Fact]
+    public void GetAllowedLibraryRootIds_NoExclusions_ReturnsEmpty()
+    {
+        // An empty exclusion set means nothing is scoped out, so callers should leave their query
+        // unrestricted rather than filtering to a subset of roots.
+        var libraryManager = new Mock<ILibraryManager>();
+
+        var ids = LibraryPathResolver.GetAllowedLibraryRootIds(
+            libraryManager.Object,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+        Assert.Empty(ids);
+        libraryManager.Verify(m => m.GetVirtualFolders(), Times.Never);
+    }
+
+    [Fact]
+    public void GetAllowedLibraryRootIds_WithExclusion_ReturnsOnlyAllowedRootIds()
+    {
+        var allowedId = Guid.NewGuid();
+        var excludedId = Guid.NewGuid();
+        var libraryManager = new Mock<ILibraryManager>();
+        libraryManager
+            .Setup(m => m.GetVirtualFolders())
+            .Returns(
+            [
+                new VirtualFolderInfo { Name = "Movies", ItemId = allowedId.ToString("N"), Locations = ["/media/movies"] },
+                new VirtualFolderInfo { Name = "Anime", ItemId = excludedId.ToString("N"), Locations = ["/media/anime"] }
+            ]);
+
+        var ids = LibraryPathResolver.GetAllowedLibraryRootIds(
+            libraryManager.Object,
+            new HashSet<string>(StringComparer.Ordinal) { "anime" });
+
+        Assert.Equal([allowedId], ids);
+    }
+
+    [Fact]
+    public void GetAllowedLibraryRootIds_UnparsableOrEmptyItemId_Skipped()
+    {
+        // A virtual folder whose item id is missing or malformed cannot scope a query, so it is left
+        // out rather than silently widening the query.
+        var allowedId = Guid.NewGuid();
+        var libraryManager = new Mock<ILibraryManager>();
+        libraryManager
+            .Setup(m => m.GetVirtualFolders())
+            .Returns(
+            [
+                new VirtualFolderInfo { Name = "Movies", ItemId = allowedId.ToString("N"), Locations = ["/media/movies"] },
+                new VirtualFolderInfo { Name = "Broken", ItemId = "not-a-guid", Locations = ["/media/broken"] },
+                new VirtualFolderInfo { Name = "NoId", ItemId = null, Locations = ["/media/noid"] },
+                new VirtualFolderInfo { Name = "Anime", ItemId = Guid.NewGuid().ToString("N"), Locations = ["/media/anime"] }
+            ]);
+
+        var ids = LibraryPathResolver.GetAllowedLibraryRootIds(
+            libraryManager.Object,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Anime" });
+
+        Assert.Equal([allowedId], ids);
+    }
+
+    [Fact]
+    public void GetAllowedLibraryRootIds_NullLibraryManager_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => LibraryPathResolver.GetAllowedLibraryRootIds(
+                null!,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Anime" }));
+    }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Recommendation/Engine/EngineExclusionTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Recommendation/Engine/EngineExclusionTests.cs
@@ -11,7 +11,10 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Persistence;
+using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
 using Moq;
 using Xunit;
 
@@ -143,6 +146,95 @@ public sealed class EngineExclusionTests
         Assert.NotNull(result);
         Assert.Contains(result!.Recommendations, r => r.ItemId == a.Id);
         Assert.Contains(result.Recommendations, r => r.ItemId == b.Id);
+    }
+
+    [Fact]
+    public void GetAllRecommendations_ExcludedLibrary_RestrictsIdfFacetQueryToAllowedRoots()
+    {
+        // The genre/studio IDF prior is aggregated by the repository from facet counts, which carry
+        // no per-item path, so the excluded library must be kept out of the query itself. With one
+        // library excluded, the facet query must be restricted to the allowed root's item id.
+        var harness = EngineTestFactory.Create();
+
+        var allowedRootId = Guid.NewGuid();
+        var excludedRootId = Guid.NewGuid();
+
+        harness.ConfigService
+            .Setup(c => c.GetConfiguration())
+            .Returns(new PluginConfiguration { ExcludedLibraries = "Home Videos" });
+        harness.LibraryManager
+            .Setup(lm => lm.GetVirtualFolders())
+            .Returns(
+            [
+                new VirtualFolderInfo { Name = "Movies", ItemId = allowedRootId.ToString("N"), CollectionType = CollectionTypeOptions.movies, Locations = ["/media/movies"] },
+                new VirtualFolderInfo { Name = "Home Videos", ItemId = excludedRootId.ToString("N"), CollectionType = CollectionTypeOptions.homevideos, Locations = ["/media/home"] }
+            ]);
+
+        Guid[]? observedGenreAncestors = null;
+        harness.ItemRepository
+            .Setup(r => r.GetGenres(It.IsAny<InternalItemsQuery>()))
+            .Callback<InternalItemsQuery>(q => observedGenreAncestors = q.AncestorIds)
+            .Returns(new QueryResult<(BaseItem, ItemCounts)>([]));
+        harness.ItemRepository
+            .Setup(r => r.GetStudios(It.IsAny<InternalItemsQuery>()))
+            .Returns(new QueryResult<(BaseItem, ItemCounts)>([]));
+
+        WireMovies(harness, [MakeMovie("Real Film", "/media/movies/real.mkv")]);
+        harness.WatchHistory.Setup(w => w.GetAllUserWatchProfiles())
+            .Returns(new Collection<UserWatchProfile>
+            {
+                new()
+                {
+                    UserId = Guid.NewGuid(),
+                    UserName = "warm",
+                    WatchedItems = new Collection<WatchedItemInfo>
+                    {
+                        new() { ItemId = Guid.NewGuid(), Name = "W", ItemType = "Movie", Played = true, PlayCount = 1, Genres = new List<string> { "Action" } }
+                    }
+                }
+            });
+
+        harness.Engine.GetAllRecommendations(10, CancellationToken.None);
+
+        Assert.NotNull(observedGenreAncestors);
+        Assert.Contains(allowedRootId, observedGenreAncestors!);
+        Assert.DoesNotContain(excludedRootId, observedGenreAncestors!);
+    }
+
+    [Fact]
+    public void GetAllRecommendations_NoExcludedLibraries_LeavesIdfFacetQueryUnrestricted()
+    {
+        // Without an exclusion the facet query must stay unrestricted so the prior is built over the
+        // whole library, matching the behavior before scoping was introduced.
+        var harness = EngineTestFactory.Create();
+
+        bool queryHadAncestors = true;
+        harness.ItemRepository
+            .Setup(r => r.GetGenres(It.IsAny<InternalItemsQuery>()))
+            .Callback<InternalItemsQuery>(q => queryHadAncestors = q.AncestorIds is { Length: > 0 })
+            .Returns(new QueryResult<(BaseItem, ItemCounts)>([]));
+        harness.ItemRepository
+            .Setup(r => r.GetStudios(It.IsAny<InternalItemsQuery>()))
+            .Returns(new QueryResult<(BaseItem, ItemCounts)>([]));
+
+        WireMovies(harness, [MakeMovie("Real Film", "/media/movies/real.mkv")]);
+        harness.WatchHistory.Setup(w => w.GetAllUserWatchProfiles())
+            .Returns(new Collection<UserWatchProfile>
+            {
+                new()
+                {
+                    UserId = Guid.NewGuid(),
+                    UserName = "warm",
+                    WatchedItems = new Collection<WatchedItemInfo>
+                    {
+                        new() { ItemId = Guid.NewGuid(), Name = "W", ItemType = "Movie", Played = true, PlayCount = 1, Genres = new List<string> { "Action" } }
+                    }
+                }
+            });
+
+        harness.Engine.GetAllRecommendations(10, CancellationToken.None);
+
+        Assert.False(queryHadAncestors);
     }
 
     [Fact]

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Recommendation/Engine/FeatureParityTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Recommendation/Engine/FeatureParityTests.cs
@@ -17,8 +17,7 @@ public sealed class FeatureParityTests
 
     [Fact]
     public void SharedHelpers_SameInputs_ProduceIdenticalValues_AcrossCallSites()
-    {
-        // A single fixed candidate + user-preference snapshot. We invoke each shared helper twice
+    {        // A single fixed candidate + user-preference snapshot. We invoke each shared helper twice
         // with the SAME data (as the live and training paths do) and assert bit-identical results.
         var franchisePrefs = new Dictionary<string, double>(Ci) { ["Marvel"] = 0.7 };
         var countryPrefs = new Dictionary<string, double>(Ci) { ["USA"] = 0.9, ["Japan"] = 0.4 };
@@ -175,5 +174,18 @@ public sealed class FeatureParityTests
     public void BillingWeight_NegativeOrder_ClampedToTopBilled()
     {
         Assert.Equal(EngineConstants.ComputeBillingWeight(0), EngineConstants.ComputeBillingWeight(-5));
+    }
+
+    [Fact]
+    public void LibraryAddedRecency_MissingDateCreated_TrainingMatchesLiveDefault()
+    {
+        // Live scoring reads a candidate's non-nullable DateCreated, so an unset value resolves to
+        // the default date and scores as very old. The training builders see a nullable DateCreated
+        // and must impute the same default rather than a neutral midpoint, or a missing library-added
+        // date would score differently between training and serving.
+        var liveMissing = ContentScoring.ComputeRecencyScore(default);
+
+        Assert.True(liveMissing < 0.01, $"A missing DateCreated must score as very old, not neutral; got {liveMissing}.");
+        Assert.NotEqual(0.5, liveMissing, 3);
     }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Recommendation/Scoring/PerUserRankingMetricsTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Recommendation/Scoring/PerUserRankingMetricsTests.cs
@@ -74,4 +74,30 @@ public sealed class PerUserRankingMetricsTests
         var result = RankingMetrics.ComputeAll(examples, strategy, k: 1);
         Assert.Equal(1.0, result.PrecisionAtK, 6);
     }
+
+    [Fact]
+    public void ComputeAll_MixedUserIds_IncludesUserlessExamplesAsOneGroup()
+    {
+        var user = Guid.NewGuid();
+        var strategy = new GenreSimilarityStrategy();
+
+        // A cache that mixes legacy user-less examples with per-user ones. The user-less
+        // cohort ranks perfectly; the real user ranks worst. If the user-less rows were
+        // dropped, the macro average would report the real user's 0.0 and hide the other half.
+        var examples = new List<TrainingExample>
+        {
+            // Legacy user-less cohort (Guid.Empty): top prediction is relevant
+            new() { Features = new CandidateFeatures { GenreSimilarity = 0.9 }, Label = 1.0 },
+            new() { Features = new CandidateFeatures { GenreSimilarity = 0.1 }, Label = 0.0 },
+            // Real user: top prediction is irrelevant
+            new() { Features = new CandidateFeatures { GenreSimilarity = 0.9 }, Label = 0.0, UserId = user },
+            new() { Features = new CandidateFeatures { GenreSimilarity = 0.1 }, Label = 1.0, UserId = user },
+        };
+
+        var (pAtK, _, _) = RankingMetrics.ComputeAll(examples, strategy, k: 1);
+
+        // Two groups: user-less cohort P@1=1.0, real user P@1=0.0 => macro 0.5.
+        // Dropping the user-less rows would yield 0.0.
+        Assert.Equal(0.5, pAtK, 6);
+    }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/DiscoveryCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/DiscoveryCacheServiceTests.cs
@@ -715,4 +715,156 @@ public sealed class DiscoveryCacheServiceTests : IDisposable
         Assert.Single(loaded);
         Assert.Equal("PostRecovery", loaded[0].Recommendations[0].Title);
     }
+
+    [Fact]
+    public async Task LoadAsync_NoFileOnDisk_ReturnsEmpty()
+    {
+        var results = await _sut.LoadAsync();
+        Assert.NotNull(results);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task LoadAsync_SavedResults_RoundTrip()
+    {
+        var userId = Guid.NewGuid();
+        _sut.Save([
+            new DiscoveryResult
+            {
+                UserId = userId,
+                Recommendations = [new DiscoveryRecommendation { TmdbId = 42, MediaType = "movie", Title = "The Answer", Score = 0.9 }]
+            }
+        ]);
+
+        var loaded = await _sut.LoadAsync();
+
+        Assert.Single(loaded);
+        Assert.Equal(userId, loaded[0].UserId);
+        Assert.Single(loaded[0].Recommendations);
+        Assert.Equal(42, loaded[0].Recommendations[0].TmdbId);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReadsFromDisk_JustLikeSyncLoad()
+    {
+        var userId = Guid.NewGuid();
+        _sut.Save([new DiscoveryResult { UserId = userId }]);
+        Assert.True(File.Exists(_cacheFilePath));
+
+        // Fresh instance so there is no pre-warmed _memoryCache and the file is actually read asynchronously.
+        using var freshSut = new DiscoveryCacheService(
+            new Mock<IPluginLogService>().Object,
+            new Mock<ILogger<DiscoveryCacheService>>().Object);
+
+        var loaded = await freshSut.LoadAsync();
+
+        Assert.Single(loaded);
+        Assert.Equal(userId, loaded[0].UserId);
+    }
+
+    [Fact]
+    public async Task LoadAsync_CorruptedJson_ReturnsEmpty_AndDoesNotThrow()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_cacheFilePath)!);
+        File.WriteAllText(_cacheFilePath, "{ this is not valid json ");
+
+        var results = await _sut.LoadAsync();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task LoadAsync_OversizedFile_DeletesFileAndReturnsEmpty()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_cacheFilePath)!);
+        using (var stream = new FileStream(
+                   _cacheFilePath,
+                   FileMode.Create,
+                   FileAccess.Write,
+                   FileShare.None))
+        {
+            // 50 MiB + 1 byte - strictly above the cap.
+            stream.SetLength((50L * 1024 * 1024) + 1);
+        }
+
+        using var freshSut = new DiscoveryCacheService(
+            new Mock<IPluginLogService>().Object,
+            new Mock<ILogger<DiscoveryCacheService>>().Object);
+
+        var results = await freshSut.LoadAsync();
+
+        Assert.Empty(results);
+        Assert.False(File.Exists(_cacheFilePath),
+            "the oversized cache file must be deleted after LoadAsync rejects it");
+    }
+
+    [Fact]
+    public async Task LoadAsync_CacheFileContainsNullEntries_FiltersNullsAndReturnsValidEntries()
+    {
+        var userId = Guid.NewGuid();
+        var json = $$"""[null, {"UserId":"{{userId}}","Recommendations":[]}]""";
+        Directory.CreateDirectory(Path.GetDirectoryName(_cacheFilePath)!);
+        File.WriteAllText(_cacheFilePath, json);
+
+        using var freshSut = new DiscoveryCacheService(
+            new Mock<IPluginLogService>().Object,
+            new Mock<ILogger<DiscoveryCacheService>>().Object);
+
+        var results = await freshSut.LoadAsync();
+
+        Assert.Single(results);
+        Assert.Equal(userId, results[0].UserId);
+    }
+
+    [Fact]
+    public async Task LoadAsync_CachesFirstRead_SecondReadDoesNotHitDeletedFile()
+    {
+        var userId = Guid.NewGuid();
+        _sut.Save([new DiscoveryResult { UserId = userId }]);
+
+        using var freshSut = new DiscoveryCacheService(
+            new Mock<IPluginLogService>().Object,
+            new Mock<ILogger<DiscoveryCacheService>>().Object);
+
+        // First read populates the in-memory cache from disk.
+        var first = await freshSut.LoadAsync();
+        Assert.Single(first);
+
+        // Deleting the backing file must not affect a subsequent load: the in-memory
+        // cache serves the second read without touching disk.
+        SafeDelete(_cacheFilePath);
+
+        var second = await freshSut.LoadAsync();
+        Assert.Single(second);
+        Assert.Equal(userId, second[0].UserId);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReturnsDetachedClones_MutatingResultDoesNotAffectCache()
+    {
+        var userId = Guid.NewGuid();
+        _sut.Save([
+            new DiscoveryResult
+            {
+                UserId = userId,
+                Recommendations = [new DiscoveryRecommendation { TmdbId = 1, MediaType = "movie", AlreadyRequested = false }]
+            }
+        ]);
+
+        var first = await _sut.LoadAsync();
+        first[0].Recommendations[0].AlreadyRequested = true;
+
+        var second = await _sut.LoadAsync();
+        Assert.False(second[0].Recommendations[0].AlreadyRequested);
+    }
+
+    [Fact]
+    public async Task LoadAsync_CancelledBeforeStart_Throws()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await _sut.LoadAsync(cts.Token));
+    }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryServiceCacheStampedeTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Seerr/Discovery/SeerrDiscoveryServiceCacheStampedeTests.cs
@@ -152,6 +152,52 @@ public sealed class SeerrDiscoveryServiceCacheStampedeTests : IDisposable
     }
 
     [Fact]
+    public async Task GetSeerrUsersAsync_ConcurrentColdMiss_CoalescesToSingleHttpRequest()
+    {
+        // A cold-cache burst must collapse onto one shared fetch rather than stampede Seerr with one
+        // roster read per caller. Only a single response is queued, so any second request would fall
+        // through to a 404 and the assertion below would fail.
+        const int concurrency = 8;
+        using var handler = new CountingHttpHandler(responseDelayMs: 30);
+        handler.EnqueueResponse("/api/v1/user", HttpStatusCode.OK, SinglePageUserJson);
+
+        var sut = BuildService(handler);
+
+        var tasks = Enumerable
+            .Range(0, concurrency)
+            .Select(_ => sut.GetSeerrUsersAsync(CancellationToken.None))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        Assert.All(results, list => Assert.Equal(3, list.Count));
+        Assert.Equal(1, handler.RequestCount("/api/v1/user"));
+    }
+
+    [Fact]
+    public async Task GetSeerrUsersAsync_OneCallerCancels_OthersStillComplete()
+    {
+        // A single caller cancelling its wait must not abort the shared fetch for the coalesced
+        // callers. The cancelling caller observes its own cancellation; the rest still get the roster.
+        using var handler = new CountingHttpHandler(responseDelayMs: 50);
+        handler.EnqueueResponse("/api/v1/user", HttpStatusCode.OK, SinglePageUserJson);
+
+        var sut = BuildService(handler);
+
+        using var cts = new CancellationTokenSource();
+        var cancelling = sut.GetSeerrUsersAsync(cts.Token);
+        var surviving = sut.GetSeerrUsersAsync(CancellationToken.None);
+
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await cancelling);
+
+        var survivingResult = await surviving;
+        Assert.Equal(3, survivingResult.Count);
+        Assert.Equal(1, handler.RequestCount("/api/v1/user"));
+    }
+
+    [Fact]
     public async Task GetSeerrUsersAsync_AfterStampede_SubsequentCallServedFromCache()
     {
         // Arrange: 4 concurrent callers warm the cache, then a 5th call should be

--- a/Jellyfin.Plugin.JellyfinHelper/Api/ConfigurationController.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Api/ConfigurationController.cs
@@ -183,7 +183,7 @@ public class ConfigurationController : ControllerBase
         [FromBody] ConfigurationUpdateRequest request,
         CancellationToken cancellationToken)
     {
-        // Model-binding and null-body diagnostics are handled by ModelBindingLogFilter, which runs with Order = int.MinValue so it fires *before* [ApiController]'s built-in ModelStateInvalidFilter.
+        // Model-binding and null-body diagnostics are handled by ModelBindingLogFilter, which orders below [ApiController]'s built-in ModelStateInvalidFilter (-2000) so it fires *before* the automatic 400.
         if (request is null)
         {
             return BadRequest(new { message = "Request body is required." });
@@ -545,11 +545,8 @@ public class ConfigurationController : ControllerBase
             config.EnsembleGenrePenaltyFloor = Math.Clamp(request.EnsembleGenrePenaltyFloor.Value, 0.0, 1.0);
         }
 
-        // Enforce min <= max after both values may have been updated.
-        if (config.EnsembleAlphaMin > config.EnsembleAlphaMax)
-        {
-            config.EnsembleAlphaMax = config.EnsembleAlphaMin;
-        }
+        // The min/max invariant is enforced by the EnsembleAlphaMin/Max setters, which swap an
+        // inverted pair on assignment; no additional reconciliation is needed here.
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.JellyfinHelper/Api/DiscoveryController.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Api/DiscoveryController.cs
@@ -50,19 +50,21 @@ public sealed class DiscoveryController : ControllerBase
     /// </summary>
     /// <param name="skip">Number of users to skip (for pagination). Clamped to &gt;= 0.</param>
     /// <param name="take">Maximum number of users to return. Clamped to 1..MaxPageSize (defaults to MaxPageSize).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A list of discovery results per user.</returns>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public ActionResult<IReadOnlyList<DiscoveryResult>> GetDiscoveryResults(
+    public async Task<ActionResult<IReadOnlyList<DiscoveryResult>>> GetDiscoveryResults(
         [FromQuery] int skip = 0,
-        [FromQuery] int? take = null)
+        [FromQuery] int? take = null,
+        CancellationToken cancellationToken = default)
     {
         // The per-user recommendation pool is already capped by MaxVisiblePerUser, but the number of users is unbounded, so a large deployment would return an arbitrarily large payload.
         const int MaxPageSize = 100;
         var effectiveSkip = Math.Max(0, skip);
         var effectiveTake = Math.Clamp(take ?? MaxPageSize, 1, MaxPageSize);
 
-        var results = _cache.Load();
+        var results = await _cache.LoadAsync(cancellationToken).ConfigureAwait(false);
 
         // Filter each user pool: only next N visible (non-dismissed, non-requested) items
         var filtered = new List<DiscoveryResult>(Math.Min(results.Count, effectiveTake));

--- a/Jellyfin.Plugin.JellyfinHelper/Api/ModelBindingLogFilter.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Api/ModelBindingLogFilter.cs
@@ -31,9 +31,9 @@ public sealed class ModelBindingLogFilter : IAsyncActionFilter, IOrderedFilter
     }
 
     /// <summary>
-    ///     Gets the filter execution order. Set to MinValue so we run before the built-in ModelStateInvalidFilter registered by [ApiController].
+    ///     Gets the filter execution order. Set below Jellyfin's own filters and the built-in ModelStateInvalidFilter (-2000) registered by [ApiController] so we run first.
     /// </summary>
-    public int Order => int.MinValue;
+    public int Order => -3000;
 
     /// <inheritdoc />
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)

--- a/Jellyfin.Plugin.JellyfinHelper/Api/UserDiscoveryController.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Api/UserDiscoveryController.cs
@@ -102,7 +102,10 @@ public sealed class UserDiscoveryController : ControllerBase
         // already requested elsewhere leaves the view and the next backfill item takes its slot.
         await MaybeReconcileAsync(currentUserId, cancellationToken).ConfigureAwait(false);
 
-        var results = _cache.Load();
+        // Read the persisted pool without the request token: reconcile above already absorbs a
+        // client disconnect, and this endpoint's contract is to still render the cached view rather
+        // than fail it. The read only touches the in-memory cache after the first load, so it is cheap.
+        var results = await _cache.LoadAsync(CancellationToken.None).ConfigureAwait(false);
         var userResult = results.FirstOrDefault(r => r.UserId.Equals(currentUserId));
         if (userResult == null)
         {

--- a/Jellyfin.Plugin.JellyfinHelper/BuildTasks/ComposeConfigPage.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/BuildTasks/ComposeConfigPage.cs
@@ -29,14 +29,23 @@ public class ComposeConfigPage : Task
         {
             var template = File.ReadAllText(TemplateFile);
 
-            var cssBuilder = new StringBuilder();
-            foreach (var trimmed in CssFiles.Split(Separator, StringSplitOptions.RemoveEmptyEntries).Select(cssFile => cssFile.Trim()))
-            {
-                if (string.IsNullOrEmpty(trimmed))
-                {
-                    continue;
-                }
+            var cssList = CssFiles.Split(Separator, StringSplitOptions.RemoveEmptyEntries)
+                .Select(cssFile => cssFile.Trim())
+                .Where(cssFile => !string.IsNullOrEmpty(cssFile))
+                .ToList();
+            var jsList = JsFiles.Split(Separator, StringSplitOptions.RemoveEmptyEntries)
+                .Select(jsFile => jsFile.Trim())
+                .Where(jsFile => !string.IsNullOrEmpty(jsFile))
+                .ToList();
 
+            if (!ValidateModuleOrder(cssList, jsList))
+            {
+                return false;
+            }
+
+            var cssBuilder = new StringBuilder();
+            foreach (var trimmed in cssList)
+            {
                 if (!File.Exists(trimmed))
                 {
                     Log.LogError("Configured CSS module was not found: {0}", trimmed);
@@ -50,13 +59,8 @@ public class ComposeConfigPage : Task
             jsBuilder.AppendLine("(function () {");
             jsBuilder.AppendLine("'use strict';");
 
-            foreach (var trimmed in JsFiles.Split(Separator, StringSplitOptions.RemoveEmptyEntries).Select(jsFile => jsFile.Trim()))
+            foreach (var trimmed in jsList)
             {
-                if (string.IsNullOrEmpty(trimmed))
-                {
-                    continue;
-                }
-
                 if (!File.Exists(trimmed))
                 {
                     Log.LogError("Configured JS module was not found: {0}", trimmed);
@@ -107,4 +111,56 @@ public class ComposeConfigPage : Task
             return false;
         }
     }
+
+    // The composed IIFE depends on a fixed module order that nothing else enforces at build time.
+    // Shared must load first so its helpers exist before any tab uses them, and Main must load
+    // last because it closes the IIFE and wires up tab routing. A silent reorder in the csproj
+    // would still concatenate cleanly but produce a broken page, so we fail the build here instead.
+    private bool ValidateModuleOrder(System.Collections.Generic.List<string> cssList, System.Collections.Generic.List<string> jsList)
+    {
+        var valid = true;
+
+        if (cssList.Count == 0)
+        {
+            Log.LogError("No CSS modules were configured; Shared.css must be present and first");
+            valid = false;
+        }
+        else if (!IsFile(cssList[0], "Shared.css"))
+        {
+            Log.LogError("First CSS module must be Shared.css but was {0}. CSS order: {1}", Path.GetFileName(cssList[0]), FileNames(cssList));
+            valid = false;
+        }
+
+        if (jsList.Count == 0)
+        {
+            Log.LogError("No JS modules were configured; Shared.js must be first and Main.js last");
+            return false;
+        }
+
+        if (!IsFile(jsList[0], "Shared.js"))
+        {
+            Log.LogError("First JS module must be Shared.js but was {0}. JS order: {1}", Path.GetFileName(jsList[0]), FileNames(jsList));
+            valid = false;
+        }
+
+        var mainIndex = jsList.FindIndex(js => IsFile(js, "Main.js"));
+        if (mainIndex < 0)
+        {
+            Log.LogError("Main.js is missing from the JS modules; it closes the IIFE and must be last. JS order: {0}", FileNames(jsList));
+            valid = false;
+        }
+        else if (mainIndex != jsList.Count - 1)
+        {
+            Log.LogError("Main.js must be the last JS module but was at position {0} of {1}. JS order: {2}", mainIndex + 1, jsList.Count, FileNames(jsList));
+            valid = false;
+        }
+
+        return valid;
+    }
+
+    private static bool IsFile(string path, string fileName)
+        => string.Equals(Path.GetFileName(path), fileName, StringComparison.OrdinalIgnoreCase);
+
+    private static string FileNames(System.Collections.Generic.List<string> paths)
+        => string.Join(", ", paths.Select(Path.GetFileName));
 }

--- a/Jellyfin.Plugin.JellyfinHelper/Jellyfin.Plugin.JellyfinHelper.csproj
+++ b/Jellyfin.Plugin.JellyfinHelper/Jellyfin.Plugin.JellyfinHelper.csproj
@@ -93,30 +93,44 @@
             <DocsI18nSource Include="$(MSBuildProjectDirectory)\i18n\*.json"/>
         </ItemGroup>
 
-        <!-- Clean target directories to mirror source (remove stale/renamed assets) -->
+        <!--
+          Sync must be crash-safe: an interruption cannot be allowed to leave docs/css, docs/js,
+          or docs/i18n emptied. So we stage the fresh assets into temporary sibling directories
+          FIRST, and only once every copy has fully succeeded do we perform the destructive swap.
+          The RemoveDir of the live directory happens immediately before the Move of its staged
+          replacement, keeping the window where docs/ is missing as small as MSBuild allows. If the
+          build is interrupted at any point during staging, the existing docs/ is still fully intact.
+        -->
+
+        <!-- Start from clean staging dirs in case a previous interrupted run left them behind -->
+        <RemoveDir Directories="$(DocsRoot)\css.tmp" Condition="Exists('$(DocsRoot)\css.tmp')"/>
+        <RemoveDir Directories="$(DocsRoot)\js.tmp" Condition="Exists('$(DocsRoot)\js.tmp')"/>
+        <RemoveDir Directories="$(DocsRoot)\i18n.tmp" Condition="Exists('$(DocsRoot)\i18n.tmp')"/>
+
+        <MakeDir Directories="$(DocsRoot)\css.tmp"/>
+        <MakeDir Directories="$(DocsRoot)\js.tmp"/>
+        <MakeDir Directories="$(DocsRoot)\i18n.tmp"/>
+
+        <!-- Stage fresh content into the temp dirs (non-destructive to the live docs/) -->
+        <Copy SourceFiles="@(DocsCssSource)" DestinationFolder="$(DocsRoot)\css.tmp"/>
+        <Copy SourceFiles="@(DocsJsSource)" DestinationFolder="$(DocsRoot)\js.tmp"/>
+        <Copy SourceFiles="@(DocsI18nSource)" DestinationFolder="$(DocsRoot)\i18n.tmp"/>
+
+        <!-- Swap staged content into place: remove the live dir then move the staged one in.
+             This is the only destructive step and runs after staging is proven to have succeeded. -->
         <RemoveDir Directories="$(DocsRoot)\css" Condition="Exists('$(DocsRoot)\css')"/>
+        <Move SourceFiles="@(DocsCssSource->'$(DocsRoot)\css.tmp\%(Filename)%(Extension)')" DestinationFolder="$(DocsRoot)\css"/>
+
         <RemoveDir Directories="$(DocsRoot)\js" Condition="Exists('$(DocsRoot)\js')"/>
+        <Move SourceFiles="@(DocsJsSource->'$(DocsRoot)\js.tmp\%(Filename)%(Extension)')" DestinationFolder="$(DocsRoot)\js"/>
+
         <RemoveDir Directories="$(DocsRoot)\i18n" Condition="Exists('$(DocsRoot)\i18n')"/>
+        <Move SourceFiles="@(DocsI18nSource->'$(DocsRoot)\i18n.tmp\%(Filename)%(Extension)')" DestinationFolder="$(DocsRoot)\i18n"/>
 
-        <!-- Recreate target directories -->
-        <MakeDir Directories="$(DocsRoot)\css"/>
-        <MakeDir Directories="$(DocsRoot)\js"/>
-        <MakeDir Directories="$(DocsRoot)\i18n"/>
-
-        <!-- Copy CSS files -->
-        <Copy SourceFiles="@(DocsCssSource)"
-              DestinationFolder="$(DocsRoot)\css"
-              SkipUnchangedFiles="true"/>
-
-        <!-- Copy JS files -->
-        <Copy SourceFiles="@(DocsJsSource)"
-              DestinationFolder="$(DocsRoot)\js"
-              SkipUnchangedFiles="true"/>
-
-        <!-- Copy i18n files -->
-        <Copy SourceFiles="@(DocsI18nSource)"
-              DestinationFolder="$(DocsRoot)\i18n"
-              SkipUnchangedFiles="true"/>
+        <!-- Remove now-empty staging dirs -->
+        <RemoveDir Directories="$(DocsRoot)\css.tmp" Condition="Exists('$(DocsRoot)\css.tmp')"/>
+        <RemoveDir Directories="$(DocsRoot)\js.tmp" Condition="Exists('$(DocsRoot)\js.tmp')"/>
+        <RemoveDir Directories="$(DocsRoot)\i18n.tmp" Condition="Exists('$(DocsRoot)\i18n.tmp')"/>
 
         <Message Importance="High" Text="Synced CSS, JS, and i18n files to docs/ for GitHub Pages demo"/>
     </Target>

--- a/Jellyfin.Plugin.JellyfinHelper/Plugin.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Plugin.cs
@@ -48,6 +48,27 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     private int _readOnlyWarningEmitted;
 
     /// <summary>
+    ///     Upper bound on the number of link hops any single path resolution will follow before
+    ///     giving up. Mirrors the typical operating-system SYMLOOP_MAX so a maliciously deep or
+    ///     cyclic chain cannot make resolution run unbounded.
+    /// </summary>
+    internal const int MaxLinkHops = 40;
+
+    /// <summary>
+    ///     Resolves the link target of a single path component against the real filesystem, returning
+    ///     the final target when the component is a symlink or junction and <c>null</c> otherwise.
+    /// </summary>
+    /// <remarks>
+    ///     An <see cref="IOException"/> raised here (for example when the OS reports <c>ELOOP</c> on a
+    ///     link cycle) is allowed to propagate so the caller can fail closed.
+    /// </remarks>
+    internal static readonly Func<string, string?> RealLeafResolver = candidate =>
+    {
+        FileSystemInfo leaf = Directory.Exists(candidate) ? new DirectoryInfo(candidate) : new FileInfo(candidate);
+        return leaf.ResolveLinkTarget(returnFinalTarget: true)?.FullName;
+    };
+
+    /// <summary>
     ///     Initializes a new instance of the <see cref="Plugin" /> class.
     /// </summary>
     /// <param name="applicationPaths">Instance of the <see cref="IApplicationPaths" /> interface.</param>
@@ -436,26 +457,60 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <param name="path">The path to canonicalize.</param>
     /// <returns>The real, fully symlink-resolved absolute path.</returns>
     private static string ResolveRealPath(string path)
+        => ResolveRealPathCore(path, RealLeafResolver);
+
+    /// <summary>
+    ///     Canonicalizes a path by resolving each ancestor directory and then following the final
+    ///     component's link target. The traversal is bounded by both <see cref="MaxLinkHops"/> and a
+    ///     visited set so that a symlink cycle terminates and returns the last resolved candidate
+    ///     rather than recursing without end.
+    /// </summary>
+    /// <param name="path">The path to canonicalize.</param>
+    /// <param name="resolveLeafLink">
+    ///     Resolves a single component's link target to its final target's full path, or <c>null</c>
+    ///     when the component is not a link. Injected so the bounded traversal is testable without
+    ///     real symlinks.
+    /// </param>
+    /// <returns>The real, fully symlink-resolved absolute path.</returns>
+    internal static string ResolveRealPathCore(string path, Func<string, string?> resolveLeafLink)
     {
+        // Paths compare case-insensitively on Windows and case-sensitively elsewhere, so the visited
+        // set must use the same comparer to detect a cycle correctly on either platform.
+        var comparer = OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        var visited = new HashSet<string>(comparer);
+
         var full = Path.GetFullPath(path);
-
-        var parent = Path.GetDirectoryName(full);
-        if (string.IsNullOrEmpty(parent))
+        var hops = 0;
+        while (true)
         {
-            // Root component (e.g. "C:\" or "/"), nothing above it to resolve.
-            return full;
+            var parent = Path.GetDirectoryName(full);
+            if (string.IsNullOrEmpty(parent))
+            {
+                // Root component (e.g. "C:\" or "/"), nothing above it to resolve.
+                return full;
+            }
+
+            // Canonicalize the parent directory chain first (recursively), then reattach this
+            // component's name and resolve the component itself if it is a link.
+            var realParent = ResolveRealPathCore(parent, resolveLeafLink);
+            var candidate = Path.Combine(realParent, Path.GetFileName(full));
+
+            var resolvedLeaf = resolveLeafLink(candidate);
+            if (resolvedLeaf == null)
+            {
+                return candidate;
+            }
+
+            // Stop once we have followed too many hops or would revisit a component, returning the
+            // last resolved candidate. This bounds a cycle without throwing.
+            if (++hops > MaxLinkHops || !visited.Add(candidate))
+            {
+                return candidate;
+            }
+
+            // The link may point through further links; iterate rather than recurse.
+            full = Path.GetFullPath(resolvedLeaf);
         }
-
-        // Canonicalize the parent directory chain first (recursively), then reattach this
-        // component's name and resolve the component itself if it is a link.
-        var realParent = ResolveRealPath(parent);
-        var candidate = Path.Combine(realParent, Path.GetFileName(full));
-
-        FileSystemInfo leaf = Directory.Exists(candidate) ? new DirectoryInfo(candidate) : new FileInfo(candidate);
-        var resolvedLeaf = leaf.ResolveLinkTarget(returnFinalTarget: true);
-        return resolvedLeaf != null
-            ? ResolveRealPath(resolvedLeaf.FullName) // link may point through further links
-            : candidate;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.JellyfinHelper/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginServiceRegistrator.cs
@@ -38,7 +38,7 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
     {
         _ = applicationHost; // Required by interface but unused
 
-        // Hardening for all outbound named clients (Arr / Seerr): * MaxResponseContentBufferSize caps how much a response body can buffer, so a compromised/MITM'd upstream cannot stream a multi-GB body into a single string and OOM the Jellyfin process (Seerr reads used unbounded.
+        // Hardening for all outbound named clients (Arr / Seerr): MaxResponseContentBufferSize caps how much a response body can buffer, so a compromised or MITM'd upstream cannot stream a multi-GB body into a single string and OOM the Jellyfin process. Seerr reads were previously unbounded.
         const long maxResponseBytes = 100L * 1024 * 1024; // 100 MB, matching ArrIntegration's LimitedStream cap
 
         static HttpMessageHandler NoRedirectHandler() =>

--- a/Jellyfin.Plugin.JellyfinHelper/Services/LibraryPathResolver.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/LibraryPathResolver.cs
@@ -93,6 +93,50 @@ public static class LibraryPathResolver
         roots.DistinctBy(NormalizeForPrefix, PathComparison.Comparer).ToList();
 
     /// <summary>
+    /// Gets the item ids of the allowed library roots, so a facet query that counts by ancestor
+    /// (rather than by item path) can be restricted to the same libraries the path scope permits.
+    /// </summary>
+    /// <remarks>
+    /// Facet aggregations such as genre and studio counts have no per-item path to post-filter, so
+    /// the exclusion must be applied to the query itself through ancestor ids. A virtual folder whose
+    /// name is excluded, or whose id does not parse, is left out. An empty result means no library is
+    /// excluded, and callers should then leave their query unrestricted.
+    /// </remarks>
+    /// <param name="libraryManager">The library manager.</param>
+    /// <param name="excludedLibraryNames">Library names to exclude (case-insensitive). May be empty.</param>
+    /// <returns>The item ids of the non-excluded library roots, or an empty list when nothing is excluded.</returns>
+    public static IReadOnlyList<Guid> GetAllowedLibraryRootIds(
+        ILibraryManager libraryManager,
+        IReadOnlySet<string> excludedLibraryNames)
+    {
+        ArgumentNullException.ThrowIfNull(libraryManager);
+        ArgumentNullException.ThrowIfNull(excludedLibraryNames);
+
+        if (excludedLibraryNames.Count == 0)
+        {
+            return [];
+        }
+
+        var excludedNames = excludedLibraryNames.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var allowedIds = new List<Guid>();
+        foreach (var folder in libraryManager.GetVirtualFolders())
+        {
+            if (excludedNames.Contains(folder.Name ?? string.Empty))
+            {
+                continue;
+            }
+
+            if (Guid.TryParse(folder.ItemId, out var id) && id != Guid.Empty)
+            {
+                allowedIds.Add(id);
+            }
+        }
+
+        return allowedIds;
+    }
+
+    /// <summary>
     /// Determines whether an item path is permitted by the supplied scope, resolving the case where
     /// an excluded root is nested under an allowed one (or vice versa).
     /// </summary>

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Recommendation/Engine/Engine.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Recommendation/Engine/Engine.cs
@@ -672,19 +672,13 @@ public sealed class Engine : IRecommendationEngine, IDisposable
     /// <returns>The per-item studios, tags and BoxSet id maps, keyed by item id.</returns>
     private Training.LibraryItemMetadata BuildLibraryItemMetadata()
     {
-        var movies = _libraryManager.GetItemList(
-            new InternalItemsQuery
-            {
-                IncludeItemTypes = [BaseItemKind.Movie],
-                IsFolder = false
-            });
+        // Scope to the same allowed roots the candidate load uses. An excluded library must not feed
+        // training-time studio, tag or BoxSet lookups for items that are never scored as candidates,
+        // or the learned model would fit on features the serve path never produces.
+        var scope = GetLibraryRootScope();
 
-        var series = _libraryManager.GetItemList(
-            new InternalItemsQuery
-            {
-                IncludeItemTypes = [BaseItemKind.Series],
-                IsFolder = true
-            });
+        var movies = QueryAllowedItems(BaseItemKind.Movie, isFolder: false, scope);
+        var series = QueryAllowedItems(BaseItemKind.Series, isFolder: true, scope);
 
         var studios = new Dictionary<Guid, IReadOnlyList<string>>(movies.Count + series.Count);
         var tags = new Dictionary<Guid, IReadOnlyList<string>>(movies.Count + series.Count);
@@ -1730,6 +1724,24 @@ public sealed class Engine : IRecommendationEngine, IDisposable
         try
         {
             var query = new InternalItemsQuery { Recursive = true };
+
+            // Facet counts are aggregated by the repository and carry no per-item path, so the
+            // excluded-library scope cannot be applied by post-filtering. Restrict the query to the
+            // allowed library roots instead, keeping this prior in parity with the scoped candidate
+            // and training-metadata queries.
+            var excluded = CleanupConfigHelper.ParseCommaSeparated(_configService.GetConfiguration().ExcludedLibraries);
+            if (excluded.Count > 0)
+            {
+                var allowedRootIds = LibraryPathResolver.GetAllowedLibraryRootIds(_libraryManager, excluded);
+                if (allowedRootIds.Count == 0)
+                {
+                    // Every library is excluded, so there is nothing to build a prior from.
+                    return table;
+                }
+
+                query.AncestorIds = [.. allowedRootIds];
+            }
+
             var rawIdf = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
             var maxIdf = 0.0;
 

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Recommendation/Engine/Training/TrainingDataBuilder.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Recommendation/Engine/Training/TrainingDataBuilder.cs
@@ -645,7 +645,7 @@ internal static class TrainingDataBuilder
             TagSimilarity = tagSimilarity,
             LibraryAddedRecency = rec.DateCreated.HasValue
                 ? ContentScoring.ComputeRecencyScore(rec.DateCreated.Value)
-                : 0.5,
+                : ContentScoring.ComputeRecencyScore(default),
             ContentNearestNeighborScore = TrainingFeatureComputer.ComputeContentNearestNeighborFromCache(
                 rec.Genres,
                 rec.PeopleNames,
@@ -1038,7 +1038,7 @@ internal static class TrainingDataBuilder
             TagSimilarity = tagSimilarity,
             LibraryAddedRecency = w.DateCreated.HasValue
                 ? ContentScoring.ComputeRecencyScore(w.DateCreated.Value)
-                : 0.5,
+                : ContentScoring.ComputeRecencyScore(default),
             LanguageAffinity = 0.5,
             SubtitleLanguageAffinity = 0.5,
             FranchiseAffinity = SimilarityComputer.ComputeFranchiseAffinity(w.TmdbCollectionName, preferredFranchisesOrganic),
@@ -1273,7 +1273,7 @@ internal static class TrainingDataBuilder
             TagSimilarity = negTagSimilarity,
             LibraryAddedRecency = neg.DateCreated.HasValue
                 ? ContentScoring.ComputeRecencyScore(neg.DateCreated.Value)
-                : 0.5,
+                : ContentScoring.ComputeRecencyScore(default),
             ContentNearestNeighborScore = TrainingFeatureComputer.ComputeContentNearestNeighborFromCache(
                 negGenres,
                 neg.PeopleNames,

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Recommendation/Scoring/CandidateFeatures.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Recommendation/Scoring/CandidateFeatures.cs
@@ -316,7 +316,7 @@ public sealed class CandidateFeatures
     }
 
     /// <summary>
-    ///     Gets or sets the hour-of-day affinity (0-1). How well this content matches the user's viewing patterns for the current time of day (e.g.
+    ///     Gets or sets the hour-of-day affinity (0-1). How well this content matches the user's viewing patterns for the current time of day, for example late-night versus morning viewing.
     /// </summary>
     public double HourOfDayAffinity
     {

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Recommendation/Scoring/RankingMetrics.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Recommendation/Scoring/RankingMetrics.cs
@@ -165,26 +165,11 @@ internal static class RankingMetrics
             return (0.0, 0.0, 0.0);
         }
 
-        // Group by user so precision reflects per-user top K rather than a global pool
-        var hasUser = examples.Any(e => e.UserId != Guid.Empty);
-        if (!hasUser)
-        {
-            var predictions = new double[examples.Count];
-            var labels = new double[examples.Count];
-
-            for (var i = 0; i < examples.Count; i++)
-            {
-                predictions[i] = strategy.Score(examples[i].Features);
-                labels[i] = examples[i].Label;
-            }
-
-            return (
-                ComputePrecisionAtK(predictions, labels, k, relevanceThreshold),
-                ComputeRecallAtK(predictions, labels, k, relevanceThreshold),
-                ComputeNdcgAtK(predictions, labels, k));
-        }
-
-        var groups = examples.Where(e => e.UserId != Guid.Empty).GroupBy(e => e.UserId);
+        // Group by user so precision reflects per-user top K rather than a global pool.
+        // Examples without a user id collapse into a single Guid.Empty group so they still
+        // contribute; a cache mixing legacy user-less examples with per-user ones would
+        // otherwise measure only the per-user subset and bias the metrics.
+        var groups = examples.GroupBy(e => e.UserId);
         var totalP = 0.0;
         var totalR = 0.0;
         var totalN = 0.0;

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/DiscoveryCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/DiscoveryCacheService.cs
@@ -123,6 +123,42 @@ public sealed class DiscoveryCacheService : IDisposable
     }
 
     /// <summary>
+    ///     Asynchronous counterpart of <see cref="Load"/>. Preferred for callers on request-driven
+    ///     paths so the request thread is not blocked on the file lock or the first-load disk read.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token honoured while waiting for the file lock.</param>
+    /// <returns>A deep-copied list of discovery results, or an empty list if the file does not exist or is invalid.</returns>
+    public async Task<IReadOnlyList<DiscoveryResult>> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            try
+            {
+                await EnsureLoadedLockedAsync(cancellationToken).ConfigureAwait(false);
+                var cache = _memoryCache ??= [];
+                return cache.ConvertAll(r => r.Clone());
+            }
+            catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
+            {
+                _pluginLog.LogWarning(
+                    LogCategory,
+                    $"Could not load discovery results from {_filePath}: {ex.Message}",
+                    ex,
+                    _logger);
+                // Cache empty result to prevent repeated failed disk reads on every API call.
+                // Next Save() will repopulate the cache with fresh data.
+                _memoryCache = [];
+                return [];
+            }
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    /// <summary>
     ///     Removes a specific TMDb item from the specified user's cached recommendation list.
     /// </summary>
     /// <param name="tmdbId">The TMDb ID of the item to remove.</param>
@@ -455,15 +491,49 @@ public sealed class DiscoveryCacheService : IDisposable
     /// </summary>
     private void EnsureLoadedLocked()
     {
-        if (_memoryCache != null)
+        if (!ShouldReadFromDisk())
         {
             return;
+        }
+
+        var json = File.ReadAllText(_filePath);
+        DeserializeIntoCache(json);
+    }
+
+    /// <summary>
+    ///     Asynchronous counterpart of <see cref="EnsureLoadedLocked"/>. Must be called while holding _fileLock.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token honoured during the disk read.</param>
+    /// <returns>A task that completes once the cache is populated.</returns>
+    private async Task EnsureLoadedLockedAsync(CancellationToken cancellationToken)
+    {
+        if (!ShouldReadFromDisk())
+        {
+            return;
+        }
+
+        var json = await File.ReadAllTextAsync(_filePath, cancellationToken).ConfigureAwait(false);
+        DeserializeIntoCache(json);
+    }
+
+    /// <summary>
+    ///     Determines whether the on-disk file needs to be read to populate the cache, applying the
+    ///     same existence and oversize-file handling as the legacy inline logic. Returns <c>false</c>
+    ///     (and sets _memoryCache) when the cache is already loaded, the file is missing, or the file
+    ///     is oversized (in which case it is deleted best-effort). Must be called while holding _fileLock.
+    /// </summary>
+    /// <returns><c>true</c> if the caller must read and deserialize the file; otherwise <c>false</c>.</returns>
+    private bool ShouldReadFromDisk()
+    {
+        if (_memoryCache != null)
+        {
+            return false;
         }
 
         if (!File.Exists(_filePath))
         {
             _memoryCache = [];
-            return;
+            return false;
         }
 
         // Reject oversized files (likely corrupted or tampered).
@@ -485,10 +555,18 @@ public sealed class DiscoveryCacheService : IDisposable
             }
 
             _memoryCache = [];
-            return;
+            return false;
         }
 
-        var json = File.ReadAllText(_filePath);
+        return true;
+    }
+
+    /// <summary>
+    ///     Deserializes the discovery-cache JSON into _memoryCache, filtering out null entries.
+    /// </summary>
+    /// <param name="json">The raw JSON read from disk.</param>
+    private void DeserializeIntoCache(string json)
+    {
         _memoryCache = JsonSerializer.Deserialize<List<DiscoveryResult>>(json, JsonOptions)
                            ?.Where(r => r != null).ToList() ?? [];
     }

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/SeerrDiscoveryService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Seerr/Discovery/SeerrDiscoveryService.cs
@@ -131,6 +131,10 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
     private IReadOnlyList<SeerrUser>? _cachedSeerrUsers;
     private DateTime _cachedSeerrUsersExpiry = DateTime.MinValue;
 
+    // Holds the in-flight roster fetch so concurrent callers coalesce onto a single Seerr request
+    // instead of each launching their own. Cleared when the fetch completes so the next miss refreshes.
+    private Task<(IReadOnlyList<SeerrUser> Users, bool Complete)>? _inflightUserFetch;
+
     /// <summary>
     ///     Initializes a new instance of the <see cref="SeerrDiscoveryService"/> class.
     /// </summary>
@@ -259,7 +263,7 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
 
         // Snapshot the previously-persisted pools once so a transient per-user failure can carry the user's
         // last-known-good pool forward instead of being wiped by the full-overwrite Save below. Keyed by user.
-        var previousByUser = _cache.Load().ToDictionary(r => r.UserId);
+        var previousByUser = (await _cache.LoadAsync(cancellationToken).ConfigureAwait(false)).ToDictionary(r => r.UserId);
 
         // Users whose pool in allResults is a carried-forward snapshot, not freshly generated this run. Their
         // items were already shown in a prior run, so they must be excluded from feedback recording to avoid
@@ -354,7 +358,7 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
         Guid jellyfinUserId,
         HashSet<(int TmdbId, string MediaType)> requestedKeys)
     {
-        var userResult = _cache.Load().FirstOrDefault(r => r.UserId.Equals(jellyfinUserId));
+        var userResult = (await _cache.LoadAsync(CancellationToken.None).ConfigureAwait(false)).FirstOrDefault(r => r.UserId.Equals(jellyfinUserId));
         if (userResult == null || userResult.Recommendations.Count == 0)
         {
             return 0;
@@ -1535,6 +1539,11 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
     /// </summary>
     private async Task<IReadOnlyList<SeerrUser>> GetCachedSeerrUsersAsync(CancellationToken cancellationToken)
     {
+        // Honor an already-cancelled token before any work. The shared fetch below runs on its own
+        // token so one caller cannot abort it for the others, which means the caller's cancellation
+        // would otherwise go unobserved on a cache hit or a synchronously completed fetch.
+        cancellationToken.ThrowIfCancellationRequested();
+
         // Fast path: check if cache is still valid under lock to ensure atomicity
         // of the (_cachedSeerrUsers, _cachedSeerrUsersExpiry) pair across threads.
         lock (_userCacheLock)
@@ -1545,8 +1554,31 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
             }
         }
 
-        // Slow path: refresh from Seerr API (outside lock to avoid blocking during I/O).
-        var (freshUsers, complete) = await FetchSeerrUsersInternalAsync(cancellationToken).ConfigureAwait(false);
+        // Slow path: coalesce concurrent callers onto one fetch so a discovery run that fans out over
+        // many users, or a burst of frontend requests, does not stampede Seerr with N parallel roster
+        // reads. The shared fetch runs on its own token so one caller cancelling does not abort it for
+        // the others; each caller still observes its own cancellation while awaiting.
+        Task<(IReadOnlyList<SeerrUser> Users, bool Complete)> fetch;
+        lock (_userCacheLock)
+        {
+            if (_cachedSeerrUsers != null && DateTime.UtcNow < _cachedSeerrUsersExpiry)
+            {
+                return _cachedSeerrUsers;
+            }
+
+            // Reuse an in-flight fetch, but never a settled one: a completed task holds a stale result
+            // (including a failed fetch that must not be cached), so a fresh miss starts a new fetch
+            // rather than replaying the old outcome. This does not depend on the completion cleanup
+            // having run yet, which would otherwise race a caller arriving right after the fetch settles.
+            if (_inflightUserFetch is not { IsCompleted: false })
+            {
+                _inflightUserFetch = StartSeerrUserFetchAsync();
+            }
+
+            fetch = _inflightUserFetch;
+        }
+
+        (IReadOnlyList<SeerrUser> freshUsers, bool complete) = await fetch.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         // Only cache complete, non-empty results to allow retry on next call when Seerr is temporarily unavailable or returns partial data.
         if (freshUsers.Count > 0 && complete)
@@ -1578,6 +1610,26 @@ public sealed class SeerrDiscoveryService : ISeerrDiscoveryService
         {
             return _cachedSeerrUsers ?? freshUsers;
         }
+    }
+
+    // Starts a single shared roster fetch and clears the in-flight slot once it settles, so the next
+    // cache miss starts a fresh fetch rather than awaiting a stale completed task. Runs on its own
+    // token so it is not cancelled by any one caller's token.
+    private Task<(IReadOnlyList<SeerrUser> Users, bool Complete)> StartSeerrUserFetchAsync()
+    {
+        var fetch = FetchSeerrUsersInternalAsync(CancellationToken.None);
+        _ = fetch.ContinueWith(
+            _ =>
+            {
+                lock (_userCacheLock)
+                {
+                    _inflightUserFetch = null;
+                }
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+        return fetch;
     }
 
     private async Task<DiscoveryResult?> GenerateForUserAsync(

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Jellyfin](https://jellyfin.org/) plugin that provides automated cleanup tasks
 
 [![Quality gate](https://img.shields.io/sonar/quality_gate/JellyPlugins_jellyfin-helper?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&logo=sonarcloud&logoColor=white&labelColor=2d333b)](https://sonarcloud.io/summary/new_code?id=JellyPlugins_jellyfin-helper)<br>
 [![codecov](https://img.shields.io/codecov/c/github/JellyPlugins/jellyfin-helper?style=flat-square&logo=codecov&logoColor=white&labelColor=2d333b)](https://codecov.io/gh/JellyPlugins/jellyfin-helper)<br>
-[![Tests](https://img.shields.io/badge/unit%20tests-5311-2ea043?style=flat-square&logo=checkmarx&logoColor=white&labelColor=2d333b)](Jellyfin.Plugin.JellyfinHelper.Tests/)<br>
+[![Tests](https://img.shields.io/badge/unit%20tests-5336-2ea043?style=flat-square&logo=checkmarx&logoColor=white&labelColor=2d333b)](Jellyfin.Plugin.JellyfinHelper.Tests/)<br>
 [![E2E](https://img.shields.io/badge/e2e%20tests-296-2ea043?style=flat-square&logo=docker&logoColor=white&labelColor=2d333b)](test/e2e/)
 
 </td>


### PR DESCRIPTION
  Recommendations
  - Scope BuildLibraryItemMetadata and BuildGenreStudioIdfTable to allowed libraries so excluded libraries no longer leak into training features (new LibraryPathResolver.GetAllowedLibraryRootIds feeds AncestorIds).
  - RankingMetrics.ComputeAll no longer drops empty-user-id examples, so a mixed cache is measured in full.
  - Impute a missing DateCreated at training time the same way live scoring does, restoring LibraryAddedRecency train/serve parity.

  Reliability
  - DiscoveryCacheService gains an async LoadAsync used on request paths instead of a blocking synchronous read.
  - Coalesce concurrent Seerr user-roster fetches onto a single request to avoid a stampede, without caching failed fetches.
  - Resolve symlink chains iteratively with a hop cap and visited set so a cycle cannot exhaust the stack at startup.

  Config and build
  - ModelBindingLogFilter orders below the built-in -2000 filter instead of int.MinValue; drop the redundant alpha-range reconciliation.
  - Guard config-page module order at build time and stage docs sync before the destructive swap.
  - Complete two truncated doc comments and the client-hardening note.

  Docs
  - Record the 38-feature vector and the weight schema version 2 to 3 breaking change in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Discovery results and cached data now load asynchronously, with cancellation support.
  - Concurrent Seerr requests are consolidated to reduce duplicate network activity.
  - Recommendations now respect excluded libraries more consistently.

- **Bug Fixes**
  - Improved handling of missing creation dates in recommendation scoring.
  - Symlink resolution now safely handles cycles and excessive link depth.
  - Documentation asset updates are more resilient to interrupted builds.

- **Tests**
  - Expanded coverage for discovery, caching, recommendations, library filtering, and path resolution.
  - Updated the documented unit-test count to 5,336.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->