### PR TITLE
Refactor: unify hover and focus styles for custom dropdowns

### DIFF
--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/css/ArrIntegration.css
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/css/ArrIntegration.css
@@ -106,19 +106,6 @@
     background-position: right 0.5em center;
     background-size: 1.3em;
     cursor: pointer;
-    transition: border-color 0.2s;
-}
-
-/* noinspection CssUnusedSymbol */
-.arr-instance-select:hover {
-    border-color: var(--color-primary);
-}
-
-/* noinspection CssUnusedSymbol */
-.arr-instance-select:focus-visible {
-    border-color: var(--color-primary);
-    outline: 2px solid var(--color-primary);
-    outline-offset: 2px;
 }
 
 /* noinspection CssUnusedSymbol */

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/css/Recommendations.css
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/css/Recommendations.css
@@ -41,11 +41,6 @@
     min-width: 200px;
 }
 
-.recs-select:focus-visible {
-    outline: 2px solid var(--color-primary, #00a4dc);
-    outline-offset: 2px;
-}
-
 .recs-select option {
     background: #2b2b2b;
     color: #e0e0e0;

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/css/Recommendations.css
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/css/Recommendations.css
@@ -204,11 +204,11 @@
 
 .recs-collapsible-toggle:hover {
     background: rgba(255, 255, 255, 0.06);
-    border-color: var(--color-primary, #00a4dc);
+    border-color: var(--color-primary);
 }
 
 .recs-collapsible-toggle:focus-visible {
-    outline: 2px solid var(--color-primary, #00a4dc);
+    outline: 2px solid var(--color-primary);
     outline-offset: 2px;
 }
 

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/css/Settings.css
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/css/Settings.css
@@ -124,6 +124,16 @@
     border-radius: var(--radius-lg);
     margin-top: 0.8em;
     overflow: hidden;
+    transition: border-color 0.2s;
+}
+
+/* The border lives on the container, so hovering or keyboard-focusing the
+   header lights up the whole collapsible edge blue - matching the dropdown
+   hover treatment defined centrally in Shared.css. */
+/* noinspection CssUnusedSymbol */
+.arr-collapsible:hover,
+.arr-collapsible:focus-within {
+    border-color: var(--color-primary);
 }
 
 /* noinspection CssUnusedSymbol */
@@ -153,7 +163,7 @@
 
 /* noinspection CssUnusedSymbol */
 .arr-collapsible-header:focus-visible {
-    outline: 2px solid var(--color-primary, #00a4dc);
+    outline: 2px solid var(--color-primary);
     outline-offset: -2px;
     background: rgba(255, 255, 255, 0.06);
 }

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/css/Shared.css
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/css/Shared.css
@@ -450,6 +450,36 @@
     vertical-align: middle;
 }
 
+/* Shared interaction states for custom-styled native <select> dropdowns.
+   The Settings tab (.settings-form select), the Arr tab (.arr-instance-select),
+   the Logs tab (.logs-toolbar select) and the Recommendations tab (.recs-select)
+   render visually consistent dropdowns; keeping their hover/focus feedback here
+   guarantees they stay in sync instead of drifting apart in per-tab stylesheets. */
+.settings-form select,
+.arr-instance-select,
+.logs-toolbar select,
+.recs-select {
+    transition: border-color 0.2s;
+}
+
+/* noinspection CssUnusedSymbol */
+.settings-form select:hover,
+.arr-instance-select:hover,
+.logs-toolbar select:hover,
+.recs-select:hover {
+    border-color: var(--color-primary);
+}
+
+/* noinspection CssUnusedSymbol */
+.settings-form select:focus-visible,
+.arr-instance-select:focus-visible,
+.logs-toolbar select:focus-visible,
+.recs-select:focus-visible {
+    border-color: var(--color-primary);
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
 .file-tree-panel {
     max-height: 0;
     overflow: hidden;

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Settings.js
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Settings.js
@@ -351,14 +351,25 @@ function renderArrCollapseButton(expanded, icon, text, countText, type) {
     return arrCollapseButton;
 }
 
-// Rebuild the entire UI after a language change
+// Rebuild the entire UI after a language change.
+// The tab contents are language-baked at render time (T() is resolved into the
+// HTML strings), so a language switch has to re-render and re-fetch the data-driven
+// tabs - there is no lighter DOM-only text swap available. To keep that full rebuild
+// from reading as a page reload, we fade the container out, swap in place, restore the
+// previously active tab (instead of jumping to Settings), then fade back in.
 function rebuildUI() {
     applyStaticTranslations();
+
+    // Remember which tab was open so the rebuild doesn't yank the user to Settings.
+    var activeBtn = document.querySelector('.tab-btn.active');
+    var activeTab = activeBtn ? activeBtn.dataset.tab : 'settings';
 
     var placeholder = document.getElementById('statsPlaceholder');
     var result = document.getElementById('statsResult');
     if (placeholder) placeholder.style.display = 'none';
     if (result) {
+        result.style.transition = 'opacity 0.18s ease';
+        result.style.opacity = '0';
         resetLogsTabState();
         result.innerHTML = renderShell();
         result.style.display = 'block';
@@ -370,9 +381,17 @@ function rebuildUI() {
     loadTrendData();
     loadInsightsData();
 
-    // Switch back to the Settings tab after rebuild
-    var settingsBtn = document.querySelector('.tab-btn[data-tab="settings"]');
-    if (settingsBtn) settingsBtn.click();
+    // Reactivate the previously open tab without going through .click(), which would
+    // re-trigger the unsaved-changes guard mid-rebuild.
+    var targetBtn = document.querySelector('.tab-btn[data-tab="' + activeTab + '"]');
+    if (targetBtn && typeof doTabSwitch === 'function') {
+        doTabSwitch(targetBtn, activeTab);
+    }
+
+    // Fade the freshly rendered UI back in on the next frame so the swap is not visible.
+    if (result) {
+        setTimeout(function () { result.style.opacity = '1'; }, 20);
+    }
 }
 
 

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Settings.js
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Settings.js
@@ -351,25 +351,14 @@ function renderArrCollapseButton(expanded, icon, text, countText, type) {
     return arrCollapseButton;
 }
 
-// Rebuild the entire UI after a language change.
-// The tab contents are language-baked at render time (T() is resolved into the
-// HTML strings), so a language switch has to re-render and re-fetch the data-driven
-// tabs - there is no lighter DOM-only text swap available. To keep that full rebuild
-// from reading as a page reload, we fade the container out, swap in place, restore the
-// previously active tab (instead of jumping to Settings), then fade back in.
+// Rebuild the entire UI after a language change
 function rebuildUI() {
     applyStaticTranslations();
-
-    // Remember which tab was open so the rebuild doesn't yank the user to Settings.
-    var activeBtn = document.querySelector('.tab-btn.active');
-    var activeTab = activeBtn ? activeBtn.dataset.tab : 'settings';
 
     var placeholder = document.getElementById('statsPlaceholder');
     var result = document.getElementById('statsResult');
     if (placeholder) placeholder.style.display = 'none';
     if (result) {
-        result.style.transition = 'opacity 0.18s ease';
-        result.style.opacity = '0';
         resetLogsTabState();
         result.innerHTML = renderShell();
         result.style.display = 'block';
@@ -381,17 +370,9 @@ function rebuildUI() {
     loadTrendData();
     loadInsightsData();
 
-    // Reactivate the previously open tab without going through .click(), which would
-    // re-trigger the unsaved-changes guard mid-rebuild.
-    var targetBtn = document.querySelector('.tab-btn[data-tab="' + activeTab + '"]');
-    if (targetBtn && typeof doTabSwitch === 'function') {
-        doTabSwitch(targetBtn, activeTab);
-    }
-
-    // Fade the freshly rendered UI back in on the next frame so the swap is not visible.
-    if (result) {
-        setTimeout(function () { result.style.opacity = '1'; }, 20);
-    }
+    // Switch back to the Settings tab after rebuild
+    var settingsBtn = document.querySelector('.tab-btn[data-tab="settings"]');
+    if (settingsBtn) settingsBtn.click();
 }
 
 


### PR DESCRIPTION
Refactor: unify hover and focus styles for custom dropdowns across multiple tabs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized hover and keyboard-focus styling for dropdown menus across Settings, Arr, Logs, and Recommendations.
  - Added smooth border transitions, highlighted borders on hover, and visible focus outlines to improve navigation and accessibility.
  - Applied the shared styling consistently across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->