### PR TITLE
feat: add support for book libraries in media statistics and UI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@
 *.css text eol=lf
 *.js text eol=lf
 *.ts text eol=lf
+*.sh text eol=lf
 *.ruleset text eol=lf
 .editorconfig text eol=lf
 .gitignore text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ test suite that runs the plugin inside a real Jellyfin server on every change.
 
 ### Tests
 - **New end-to-end test suite.** Alongside the unit tests, the plugin now runs inside a real Jellyfin 12 server (in a throwaway container, with stand-in Radarr/Sonarr/Jellyseerr services) and is exercised the way a real user would: changing settings, running each cleanup mode, importing/exporting a backup, and clicking through every dashboard tab. It also deliberately throws bad and hostile input at the plugin and uses "canary" files to prove that cleanup never deletes or touches anything outside your libraries, and that every admin-only action stays locked to admins. **305 tests across 48 files**, running automatically on every change plus a nightly full run.
-- **Unit tests: 5453 total** Including full coverage of the typed API responses.
+- **Unit tests: 5458 total** Including full coverage of the typed API responses.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ test suite that runs the plugin inside a real Jellyfin server on every change.
 - **More reliable backup restore.** Restore is lock-guarded and writes history data before configuration, an age of 0 is honoured, and only normal web addresses are accepted.
 
 ### Tests
-- **New end-to-end test suite.** Alongside the unit tests, the plugin now runs inside a real Jellyfin 12 server (in a throwaway container, with stand-in Radarr/Sonarr/Jellyseerr services) and is exercised the way a real user would: changing settings, running each cleanup mode, importing/exporting a backup, and clicking through every dashboard tab. It also deliberately throws bad and hostile input at the plugin and uses "canary" files to prove that cleanup never deletes or touches anything outside your libraries, and that every admin-only action stays locked to admins. **305 tests across 48 files**, running automatically on every change plus a nightly full run.
+- **New end-to-end test suite.** Alongside the unit tests, the plugin now runs inside a real Jellyfin 12 server (in a throwaway container, with stand-in Radarr/Sonarr/Jellyseerr services) and is exercised the way a real user would: changing settings, running each cleanup mode, importing/exporting a backup, and clicking through every dashboard tab. It also deliberately throws bad and hostile input at the plugin and uses "canary" files to prove that cleanup never deletes or touches anything outside your libraries, and that every admin-only action stays locked to admins. **309 tests across 48 files**, running automatically on every change plus a nightly full run.
 - **Unit tests: 5458 total** Including full coverage of the typed API responses.
 
 ---

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/CodecsHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/CodecsHtmlTests.cs
@@ -168,4 +168,13 @@ public class CodecsHtmlTests : ConfigPageTestBase
     {
         Assert.Contains("donut-tooltip", HtmlContent);
     }
+
+    [Fact]
+    public void Html_CollectCodecPaths_IncludesBookRootPaths()
+    {
+        // The book-format drill-down needs BookRootPaths so renderFileTree can trim a
+        // common prefix, matching movies/tvShows/music. Guards against the field being
+        // dropped from collectCodecPaths.rootPaths.
+        Assert.Contains("books: data.BookRootPaths || []", HtmlContent);
+    }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/MainHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/MainHtmlTests.cs
@@ -237,14 +237,18 @@ public class MainHtmlTests : ConfigPageTestBase
     [Fact]
     public void Html_StatisticsLoad_RetriesTransientAuthFailures()
     {
-        // On a browser refresh the stats request can race ApiClient token readiness
-        // and return 401/403. The loader must retry transient unauthorized/network
-        // failures (bounded) instead of immediately flashing the admin-error banner.
-        Assert.Contains("_statsAuthRetries", HtmlContent);
-        Assert.Contains("_maxStatsAuthRetries", HtmlContent);
+        // On a browser refresh the persisted-statistics read can race ApiClient token
+        // readiness and return 401/403. The loader must retry that idempotent read
+        // (bounded) instead of immediately flashing the admin-error banner.
+        Assert.Contains("_latestStatsAuthRetries", HtmlContent);
+        Assert.Contains("_maxLatestStatsAuthRetries", HtmlContent);
         Assert.Contains("describeApiError", HtmlContent);
         // The retry must be gated on transient kinds only, so a genuine non-admin
         // still sees the error after retries are exhausted.
         Assert.Contains("kind === 'unauthorized'", HtmlContent);
+        // ScanLibraries starts work, so it must retry the Latest read - never re-issue
+        // the scan on a transient failure (which could trigger a duplicate scan).
+        Assert.Contains("setTimeout(loadLatestStatistics", HtmlContent);
+        Assert.DoesNotContain("setTimeout(loadStatistics, _", HtmlContent);
     }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/MainHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/MainHtmlTests.cs
@@ -233,4 +233,18 @@ public class MainHtmlTests : ConfigPageTestBase
         // btnScanLibraries gets its icon from SVG.REFRESH
         Assert.Contains("SVG.REFRESH", HtmlContent);
     }
+
+    [Fact]
+    public void Html_StatisticsLoad_RetriesTransientAuthFailures()
+    {
+        // On a browser refresh the stats request can race ApiClient token readiness
+        // and return 401/403. The loader must retry transient unauthorized/network
+        // failures (bounded) instead of immediately flashing the admin-error banner.
+        Assert.Contains("_statsAuthRetries", HtmlContent);
+        Assert.Contains("_maxStatsAuthRetries", HtmlContent);
+        Assert.Contains("describeApiError", HtmlContent);
+        // The retry must be gated on transient kinds only, so a genuine non-admin
+        // still sees the error after retries are exhausted.
+        Assert.Matches(new Regex(@"kind\s*===\s*['""]unauthorized['""]"), HtmlContent);
+    }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/MainHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/MainHtmlTests.cs
@@ -245,6 +245,6 @@ public class MainHtmlTests : ConfigPageTestBase
         Assert.Contains("describeApiError", HtmlContent);
         // The retry must be gated on transient kinds only, so a genuine non-admin
         // still sees the error after retries are exhausted.
-        Assert.Matches(new Regex(@"kind\s*===\s*['""]unauthorized['""]"), HtmlContent);
+        Assert.Contains("kind === 'unauthorized'", HtmlContent);
     }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/SettingsHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/SettingsHtmlTests.cs
@@ -326,4 +326,16 @@ public class SettingsHtmlTests : ConfigPageTestBase
         Assert.Contains("!seerrConfigured ? 'opacity:0.5;pointer-events:none;' : ''", HtmlContent);
         Assert.Contains("!seerrHasCfg ? 'opacity:0.5;pointer-events:none;' : ''", HtmlContent);
     }
+
+    [Fact]
+    public void Html_ExcludedLibraries_ReadsBothApiCasings()
+    {
+        // Jellyfin 12 serializes controller responses in PascalCase (data.Libraries),
+        // Jellyfin 10.x used camelCase (data.libraries). The multi-select must accept
+        // both, otherwise the dropdown shows "No data" on JF12. Guards the dual-casing
+        // read on the /Configuration/Libraries response and its entry fields.
+        Assert.Contains("data.Libraries || data.libraries", HtmlContent);
+        Assert.Contains("entry.Name || entry.name", HtmlContent);
+        Assert.Contains("entry.CollectionType || entry.collectionType", HtmlContent);
+    }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/SharedHtmlTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/PluginPages/SharedHtmlTests.cs
@@ -399,4 +399,14 @@ public class SharedHtmlTests : ConfigPageTestBase
         var colorCount = Regex.Matches(match.Groups[1].Value, @"#[0-9a-fA-F]{6}").Count;
         Assert.True(colorCount >= 10, $"Expected at least 10 donut colors, found {colorCount}.");
     }
+
+    [Fact]
+    public void Html_RenderFileTree_RendersBooksSection()
+    {
+        // renderFileTree must render a Books section (badge-books) fed by result.books.
+        // Without it, a book-only drill-down showed "No files found" because totalFiles
+        // excluded books. Guards the books branch inside renderFileTree.
+        Assert.Contains("badge-books", HtmlContent);
+        Assert.Contains("buildPathTree(result.books, roots.books)", HtmlContent);
+    }
 }

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Statistics/MediaStatisticsResultTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Statistics/MediaStatisticsResultTests.cs
@@ -369,6 +369,16 @@ public class MediaStatisticsResultTests
     }
 
     [Fact]
+    public void BookRootPaths_AggregatesFromBooks()
+    {
+        var result = new MediaStatisticsResult();
+        var lib = new LibraryStatistics();
+        lib.RootPaths.Add("/media/books");
+        result.Books.Add(lib);
+        Assert.Contains("/media/books", result.BookRootPaths);
+    }
+
+    [Fact]
     public void OtherRootPaths_AggregatesFromOther()
     {
         var result = new MediaStatisticsResult();

--- a/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Statistics/MediaStatisticsServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinHelper.Tests/Services/Statistics/MediaStatisticsServiceTests.cs
@@ -401,6 +401,17 @@ public class MediaStatisticsServiceTests
         Assert.Equal(2_500, lib.BookFormatSizes["EPUB"]);
         Assert.Equal(4_000, lib.BookFormatSizes["PDF"]);
 
+        // Per-format file paths back the codec-tab drill-down (was missing, so the
+        // book drill-down always rendered "No files found").
+        Assert.Equal(2, lib.BookFormatPaths["EPUB"].Count);
+        Assert.Single(lib.BookFormatPaths["PDF"]);
+        Assert.Contains(TestPath("media", "books", "a.epub"), lib.BookFormatPaths["EPUB"]);
+        Assert.Contains(TestPath("media", "books", "b.epub"), lib.BookFormatPaths["EPUB"]);
+        Assert.Contains(TestPath("media", "books", "c.pdf"), lib.BookFormatPaths["PDF"]);
+
+        // BookRootPaths exposes the library root so the drill-down can trim a common prefix.
+        Assert.Contains(libraryPath, result.BookRootPaths);
+
         // Aggregated result-level breakdown mirrors the per-library data.
         Assert.Equal(2, result.TotalBookFormats["EPUB"]);
         Assert.Equal(3, result.TotalBookFileCount);

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Codecs.js
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Codecs.js
@@ -295,6 +295,7 @@ function collectCodecPaths(data, pathsProp, codecName, categories) {
             movies: data.MovieRootPaths || [],
             tvShows: data.TvShowRootPaths || [],
             music: data.MusicRootPaths || [],
+            books: data.BookRootPaths || [],
             other: data.OtherRootPaths || []
         }
     };

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Main.js
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Main.js
@@ -80,6 +80,7 @@ function updateLastScanBadge(utcTimestamp) {
 // Load the latest persisted statistics (no new scan) and populate tabs if available
 function loadLatestStatistics() {
     apiGetOptional('JellyfinHelper/MediaStatistics/Latest', function (data) {
+        window.JellyfinHelper._statsAuthRetries = 0;
         if (data?.Libraries) {
             fillScanData(data);
             updateLastScanBadge(data.ScanTimestamp);
@@ -88,8 +89,25 @@ function loadLatestStatistics() {
         // 204 - no persisted data yet, auto-trigger initial scan.
         // loadStatistics() will call loadTrendData(true) and loadInsightsData()
         // on its own success path, so do not issue those calls here too.
+        window.JellyfinHelper._statsAuthRetries = 0;
         console.log('Jellyfin Helper: No persisted statistics (204), triggering initial scan...');
         loadStatistics();
+    }, function (err) {
+        // On refresh this can fire before the ApiClient token is ready (transient
+        // 401/403) or during a network blip. Retry a bounded number of times before
+        // giving up, so persisted stats still load without forcing a full rescan and
+        // without flashing the admin-permission error.
+        var d = describeApiError(err);
+        var transient = d.kind === 'unauthorized' || d.kind === 'network';
+        if (transient && window.JellyfinHelper._statsAuthRetries < _maxStatsAuthRetries) {
+            window.JellyfinHelper._statsAuthRetries++;
+            console.warn('Jellyfin Helper: latest statistics not ready yet (status=' + d.status
+                + '), retry ' + window.JellyfinHelper._statsAuthRetries + '/' + _maxStatsAuthRetries);
+            setTimeout(loadLatestStatistics, _statsAuthRetryDelayMs);
+            return;
+        }
+        window.JellyfinHelper._statsAuthRetries = 0;
+        _apiDefaultError('GET', 'JellyfinHelper/MediaStatistics/Latest')(err);
     });
 }
 
@@ -187,8 +205,17 @@ window.JellyfinHelper._pageInitialized = false;
 window.JellyfinHelper._initRetries = 0;
 window.JellyfinHelper._handlersBound = false;
 window.JellyfinHelper._pageLifecycleBound = false;
+window.JellyfinHelper._statsAuthRetries = 0;
 
 var _maxInitRetries = 20;
+
+// On a full-page refresh the plugin scripts can run before Jellyfin's ApiClient
+// has its access token ready, so the first stats request comes back 401/403.
+// That is transient: retry a few times with a short backoff before surfacing the
+// "you must be an administrator" message, so a genuine admin never sees the flash.
+var _maxStatsAuthRetries = 8;
+var _statsAuthRetryDelayMs = 400;
+
 
 function loadStatistics() {
     if (window.JellyfinHelper._statisticsInFlight) {
@@ -214,6 +241,7 @@ function loadStatistics() {
 
     apiGet('JellyfinHelper/MediaStatistics/ScanLibraries', function (data) {
         window.JellyfinHelper._statisticsInFlight = false;
+        window.JellyfinHelper._statsAuthRetries = 0;
         if (loading) {
             loading.style.display = 'none';
         }
@@ -231,6 +259,22 @@ function loadStatistics() {
         loadInsightsData();
     }, function (err) {
         window.JellyfinHelper._statisticsInFlight = false;
+
+        // A refresh can fire this request before Jellyfin's ApiClient token is
+        // ready, yielding a transient 401/403 (or a network blip). Retry a bounded
+        // number of times before showing the admin-permission message, so a real
+        // admin never sees a spurious error flash on reload.
+        var d = describeApiError(err);
+        var transient = d.kind === 'unauthorized' || d.kind === 'network';
+        if (transient && window.JellyfinHelper._statsAuthRetries < _maxStatsAuthRetries) {
+            window.JellyfinHelper._statsAuthRetries++;
+            console.warn('Jellyfin Helper: statistics not ready yet (status=' + d.status
+                + '), retry ' + window.JellyfinHelper._statsAuthRetries + '/' + _maxStatsAuthRetries);
+            setTimeout(loadStatistics, _statsAuthRetryDelayMs);
+            return;
+        }
+        window.JellyfinHelper._statsAuthRetries = 0;
+
         if (loading) {
             loading.style.display = 'none';
         }

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Main.js
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Main.js
@@ -80,7 +80,7 @@ function updateLastScanBadge(utcTimestamp) {
 // Load the latest persisted statistics (no new scan) and populate tabs if available
 function loadLatestStatistics() {
     apiGetOptional('JellyfinHelper/MediaStatistics/Latest', function (data) {
-        window.JellyfinHelper._statsAuthRetries = 0;
+        window.JellyfinHelper._latestStatsAuthRetries = 0;
         if (data?.Libraries) {
             fillScanData(data);
             updateLastScanBadge(data.ScanTimestamp);
@@ -89,24 +89,24 @@ function loadLatestStatistics() {
         // 204 - no persisted data yet, auto-trigger initial scan.
         // loadStatistics() will call loadTrendData(true) and loadInsightsData()
         // on its own success path, so do not issue those calls here too.
-        window.JellyfinHelper._statsAuthRetries = 0;
+        window.JellyfinHelper._latestStatsAuthRetries = 0;
         console.log('Jellyfin Helper: No persisted statistics (204), triggering initial scan...');
         loadStatistics();
     }, function (err) {
         // On refresh this can fire before the ApiClient token is ready (transient
-        // 401/403) or during a network blip. Retry a bounded number of times before
-        // giving up, so persisted stats still load without forcing a full rescan and
-        // without flashing the admin-permission error.
+        // 401/403) or during a network blip. Retry this idempotent read a bounded
+        // number of times before giving up, so persisted stats still load without
+        // forcing a full rescan and without flashing the admin-permission error.
         var d = describeApiError(err);
         var transient = d.kind === 'unauthorized' || d.kind === 'network';
-        if (transient && window.JellyfinHelper._statsAuthRetries < _maxStatsAuthRetries) {
-            window.JellyfinHelper._statsAuthRetries++;
+        if (transient && window.JellyfinHelper._latestStatsAuthRetries < _maxLatestStatsAuthRetries) {
+            window.JellyfinHelper._latestStatsAuthRetries++;
             console.warn('Jellyfin Helper: latest statistics not ready yet (status=' + d.status
-                + '), retry ' + window.JellyfinHelper._statsAuthRetries + '/' + _maxStatsAuthRetries);
-            setTimeout(loadLatestStatistics, _statsAuthRetryDelayMs);
+                + '), retry ' + window.JellyfinHelper._latestStatsAuthRetries + '/' + _maxLatestStatsAuthRetries);
+            setTimeout(loadLatestStatistics, _latestStatsAuthRetryDelayMs);
             return;
         }
-        window.JellyfinHelper._statsAuthRetries = 0;
+        window.JellyfinHelper._latestStatsAuthRetries = 0;
         _apiDefaultError('GET', 'JellyfinHelper/MediaStatistics/Latest')(err);
     });
 }
@@ -205,16 +205,18 @@ window.JellyfinHelper._pageInitialized = false;
 window.JellyfinHelper._initRetries = 0;
 window.JellyfinHelper._handlersBound = false;
 window.JellyfinHelper._pageLifecycleBound = false;
-window.JellyfinHelper._statsAuthRetries = 0;
+window.JellyfinHelper._latestStatsAuthRetries = 0;
 
 var _maxInitRetries = 20;
 
 // On a full-page refresh the plugin scripts can run before Jellyfin's ApiClient
-// has its access token ready, so the first stats request comes back 401/403.
-// That is transient: retry a few times with a short backoff before surfacing the
-// "you must be an administrator" message, so a genuine admin never sees the flash.
-var _maxStatsAuthRetries = 8;
-var _statsAuthRetryDelayMs = 400;
+// has its access token ready, so the first read of persisted statistics comes back
+// 401/403. That is transient: retry the idempotent Latest query a few times with a
+// short backoff before surfacing the "you must be an administrator" message, so a
+// genuine admin never sees the flash. We only ever retry the read - never the scan
+// (ScanLibraries starts work and must not be re-issued on a lost response).
+var _maxLatestStatsAuthRetries = 8;
+var _latestStatsAuthRetryDelayMs = 400;
 
 
 function loadStatistics() {
@@ -241,7 +243,6 @@ function loadStatistics() {
 
     apiGet('JellyfinHelper/MediaStatistics/ScanLibraries', function (data) {
         window.JellyfinHelper._statisticsInFlight = false;
-        window.JellyfinHelper._statsAuthRetries = 0;
         if (loading) {
             loading.style.display = 'none';
         }
@@ -260,21 +261,11 @@ function loadStatistics() {
     }, function (err) {
         window.JellyfinHelper._statisticsInFlight = false;
 
-        // A refresh can fire this request before Jellyfin's ApiClient token is
-        // ready, yielding a transient 401/403 (or a network blip). Retry a bounded
-        // number of times before showing the admin-permission message, so a real
-        // admin never sees a spurious error flash on reload.
-        var d = describeApiError(err);
-        var transient = d.kind === 'unauthorized' || d.kind === 'network';
-        if (transient && window.JellyfinHelper._statsAuthRetries < _maxStatsAuthRetries) {
-            window.JellyfinHelper._statsAuthRetries++;
-            console.warn('Jellyfin Helper: statistics not ready yet (status=' + d.status
-                + '), retry ' + window.JellyfinHelper._statsAuthRetries + '/' + _maxStatsAuthRetries);
-            setTimeout(loadStatistics, _statsAuthRetryDelayMs);
-            return;
-        }
-        window.JellyfinHelper._statsAuthRetries = 0;
-
+        // ScanLibraries starts a scan (it stamps the last-scan time before computing),
+        // so it must NOT be auto-retried - a retried request can kick off a duplicate
+        // scan. The refresh-time auth race is handled by retrying the idempotent
+        // Latest query in loadLatestStatistics instead; here we simply surface the
+        // failure (a failed manual scan legitimately shows the error).
         if (loading) {
             loading.style.display = 'none';
         }

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Settings.js
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Settings.js
@@ -925,13 +925,17 @@ function showTrashDeleteConfirmation(payload, paths) {
         msg.innerHTML = '<div style="opacity:0.6;">' + escHtml(T('trashDeleting', 'Deleting trash folders…')) + '</div>';
 
         apiDelete('JellyfinHelper/Trash/Folders', function (result) {
+            // Jellyfin 12 serializes controller DTOs in PascalCase (Deleted/Failed);
+            // Jellyfin 10.x used camelCase. Accept both.
+            var deletedCount = result && (result.Deleted != null ? result.Deleted : result.deleted);
+            var failedCount = result && (result.Failed != null ? result.Failed : result.failed);
             var summary = '';
             var statusClass = 'success-msg';
-            if (result.deleted > 0) {
-                summary += mi('check_circle') + ' ' + escHtml(T('trashDeletedCount', 'Deleted')) + ': ' + (Math.max(0, Number.parseInt(result.deleted, 10) || 0)) + ' ' + escHtml(T('folders', 'folders'));
+            if (deletedCount > 0) {
+                summary += mi('check_circle') + ' ' + escHtml(T('trashDeletedCount', 'Deleted')) + ': ' + (Math.max(0, Number.parseInt(deletedCount, 10) || 0)) + ' ' + escHtml(T('folders', 'folders'));
             }
-            if (result.failed > 0) {
-                summary += (summary ? ' | ' : '') + mi('error') + ' ' + escHtml(T('trashFailedCount', 'Failed')) + ': ' + (Math.max(0, Number.parseInt(result.failed, 10) || 0));
+            if (failedCount > 0) {
+                summary += (summary ? ' | ' : '') + mi('error') + ' ' + escHtml(T('trashFailedCount', 'Failed')) + ': ' + (Math.max(0, Number.parseInt(failedCount, 10) || 0));
                 statusClass = 'error-msg';
             }
             if (!summary) {
@@ -1172,8 +1176,12 @@ function attachSeerrHandlers() {
         btn.innerHTML = '<span class="btn-spinner"></span>' + escHtml(T('testing', 'Testing…'));
         apiPost('JellyfinHelper/Seerr/Test', {Url: url, ApiKey: key}, function (res) {
             btn.disabled = false;
-            if (res && res.success) {
-                _seerrTimer = showButtonFeedback(btn, true, res.message || 'OK', originalHtml);
+            // Jellyfin 12 serializes controller DTOs in PascalCase (Success/Message);
+            // Jellyfin 10.x used camelCase. Accept both.
+            var testOk = res && (res.Success || res.success);
+            var testMsg = res && (res.Message || res.message);
+            if (testOk) {
+                _seerrTimer = showButtonFeedback(btn, true, testMsg || 'OK', originalHtml);
                 // Auto-save settings after successful connection test (quiet to avoid double feedback)
                 var payload = buildSettingsPayload();
                 doSaveSettings(payload, {quiet: true, element: document.getElementById('arrCollapsibleHeaderSeerr')});
@@ -1182,7 +1190,7 @@ function attachSeerrHandlers() {
                 // Refresh the Discovery wrapper (depends on Seerr being configured)
                 refreshDiscoveryAccessState();
             } else {
-                _seerrTimer = showButtonFeedback(btn, false, res.message || 'Failed', originalHtml);
+                _seerrTimer = showButtonFeedback(btn, false, testMsg || 'Failed', originalHtml);
             }
         }, function () {
             btn.disabled = false;
@@ -1454,7 +1462,7 @@ function initLibraryMultiSelects(cfg) {
     }
 
     apiGet('JellyfinHelper/Configuration/Libraries', function (data) {
-        var libraries = (data && data.libraries) || [];
+        var libraries = (data && (data.Libraries || data.libraries)) || [];
         var excludedSet = parseCommaSeparatedSet(cfg.ExcludedLibraries || '');
 
         renderLibraryMultiSelect('cfgExcludedWrapper', libraries, excludedSet, 'excluded');
@@ -1463,6 +1471,21 @@ function initLibraryMultiSelects(cfg) {
         var excWrap = document.getElementById('cfgExcludedWrapper');
         if (excWrap) excWrap.innerHTML = '<input type="text" id="cfgExcludedFallback" value="' + escAttr(cfg.ExcludedLibraries || '') + '">';
     });
+}
+
+/**
+ * Reads a library entry's name across Jellyfin API casings. Jellyfin 12 serializes
+ * controller DTOs in PascalCase (Name).
+ */
+function libraryEntryName(entry) {
+    return (entry && (entry.Name || entry.name)) || '';
+}
+
+/**
+ * Reads a library entry's collection type across Jellyfin API casings (see libraryEntryName).
+ */
+function libraryEntryType(entry) {
+    return (entry && (entry.CollectionType || entry.collectionType)) || '';
 }
 
 /**
@@ -1488,7 +1511,7 @@ function renderLibraryMultiSelect(wrapperId, libraries, selectedSet, type) {
     // (renamed/deleted). Store them so getLibraryMultiSelectValue() can preserve them.
     var available = {};
     for (var ai = 0; ai < libraries.length; ai++) {
-        available[libraries[ai].name.toLowerCase()] = true;
+        available[libraryEntryName(libraries[ai]).toLowerCase()] = true;
     }
     var missingSelected = [];
     for (var key in selectedSet) {
@@ -1520,11 +1543,13 @@ function renderLibraryMultiSelect(wrapperId, libraries, selectedSet, type) {
     } else {
         for (var i = 0; i < libraries.length; i++) {
             var lib = libraries[i];
-            var isChecked = !!(selectedSet[lib.name.toLowerCase()]);
+            var libName = libraryEntryName(lib);
+            var libType = libraryEntryType(lib);
+            var isChecked = !!(selectedSet[libName.toLowerCase()]);
             var checkId = wrapperId + '_lib_' + i;
             h += '<div class="library-multiselect-item">';
-            h += '<input type="checkbox" id="' + checkId + '" value="' + escAttr(lib.name) + '"' + (isChecked ? ' checked' : '') + '>';
-            h += '<label for="' + checkId + '">' + escHtml(lib.name) + ' <span class="library-type-badge">' + escHtml(lib.collectionType) + '</span></label>';
+            h += '<input type="checkbox" id="' + checkId + '" value="' + escAttr(libName) + '"' + (isChecked ? ' checked' : '') + '>';
+            h += '<label for="' + checkId + '">' + escHtml(libName) + ' <span class="library-type-badge">' + escHtml(libType) + '</span></label>';
             h += '</div>';
         }
     }

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Shared.js
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Shared.js
@@ -209,14 +209,15 @@ function renderFileTree(result, title) {
     var hasMovies = result.movies && result.movies.length > 0;
     var hasTvShows = result.tvShows && result.tvShows.length > 0;
     var hasMusic = result.music && result.music.length > 0;
+    var hasBooks = result.books && result.books.length > 0;
     var hasOther = result.other && result.other.length > 0;
-    var totalFiles = (result.movies ? result.movies.length : 0) + (result.tvShows ? result.tvShows.length : 0) + (result.music ? result.music.length : 0) + (result.other ? result.other.length : 0);
+    var totalFiles = (result.movies ? result.movies.length : 0) + (result.tvShows ? result.tvShows.length : 0) + (result.music ? result.music.length : 0) + (result.books ? result.books.length : 0) + (result.other ? result.other.length : 0);
 
     if (totalFiles === 0) {
         return '<div class="file-tree-empty">' + escHtml(T('noFilesFound', 'No files found.')) + '</div>';
     }
 
-    var sectionCount = (hasMovies ? 1 : 0) + (hasTvShows ? 1 : 0) + (hasMusic ? 1 : 0) + (hasOther ? 1 : 0);
+    var sectionCount = (hasMovies ? 1 : 0) + (hasTvShows ? 1 : 0) + (hasMusic ? 1 : 0) + (hasBooks ? 1 : 0) + (hasOther ? 1 : 0);
     var html = '<div class="file-tree-header">';
     html += '<span class="file-tree-title">' + escHtml(title) + '</span>';
     html += '<div style="display:flex;gap:0.5em;align-items:center;">';
@@ -250,6 +251,14 @@ function renderFileTree(result, title) {
         html += '<div class="file-tree-section-header"><span class="badge badge-music">' + escHtml(T('music', 'Music')) + '</span> <span class="file-tree-section-count">(' + result.music.length + ')</span></div>';
         html += '<div class="tree-view">';
         html += renderTreeLevel(buildPathTree(result.music, roots.music), 0, mi('music_note'));
+        html += '</div></div>';
+    }
+
+    if (hasBooks) {
+        html += '<div class="file-tree-section">';
+        html += '<div class="file-tree-section-header"><span class="badge badge-books">' + escHtml(T('books', 'Books')) + '</span> <span class="file-tree-section-count">(' + result.books.length + ')</span></div>';
+        html += '<div class="tree-view">';
+        html += renderTreeLevel(buildPathTree(result.books, roots.books), 0, mi('description'));
         html += '</div></div>';
     }
 

--- a/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Shared.js
+++ b/Jellyfin.Plugin.JellyfinHelper/PluginPages/js/Shared.js
@@ -639,7 +639,13 @@ function apiGetOptional(path, onSuccess, onNoContent, onError) {
             if (onNoContent) onNoContent();
             return;
         }
-        if (!response.ok) throw new Error('HTTP ' + response.status);
+        if (!response.ok) {
+            // Attach the HTTP status so describeApiError can classify it (e.g. 401/403
+            // -> "unauthorized"); a bare Error would be read as status 0 ("network").
+            var httpErr = new Error('HTTP ' + response.status);
+            httpErr.status = response.status;
+            throw httpErr;
+        }
         return response.json().then(onSuccess || function () {
         });
     }).catch(errHandler);

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Statistics/LibraryStatistics.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Statistics/LibraryStatistics.cs
@@ -203,6 +203,12 @@ public class LibraryStatistics
     public Dictionary<string, Collection<string>> ContainerFormatPaths { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Gets the book format file paths (format -> list of file paths). Populated for eBook
+    /// libraries so the codec-tab drill-down can list the files behind each book format.
+    /// </summary>
+    public Dictionary<string, Collection<string>> BookFormatPaths { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Gets the resolution file paths (resolution -> list of file paths).
     /// </summary>
     public Dictionary<string, Collection<string>> ResolutionPaths { get; } = new(StringComparer.OrdinalIgnoreCase);

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Statistics/MediaStatisticsResult.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Statistics/MediaStatisticsResult.cs
@@ -236,6 +236,12 @@ public class MediaStatisticsResult
     public HashSet<string> MusicRootPaths => new(Music.SelectMany(l => l.RootPaths), StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Gets the set of root paths for all book libraries.
+    /// </summary>
+    [JsonInclude]
+    public HashSet<string> BookRootPaths => new(Books.SelectMany(l => l.RootPaths), StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Gets the set of root paths for all other libraries.
     /// </summary>
     [JsonInclude]

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Statistics/MediaStatisticsResult.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Statistics/MediaStatisticsResult.cs
@@ -221,31 +221,45 @@ public class MediaStatisticsResult
     /// Gets the set of root paths for all movie libraries.
     /// </summary>
     [JsonInclude]
-    public HashSet<string> MovieRootPaths => new(Movies.SelectMany(l => l.RootPaths), StringComparer.OrdinalIgnoreCase);
+    public HashSet<string> MovieRootPaths => AggregateRootPaths(Movies);
 
     /// <summary>
     /// Gets the set of root paths for all TV show libraries.
     /// </summary>
     [JsonInclude]
-    public HashSet<string> TvShowRootPaths => new(TvShows.SelectMany(l => l.RootPaths), StringComparer.OrdinalIgnoreCase);
+    public HashSet<string> TvShowRootPaths => AggregateRootPaths(TvShows);
 
     /// <summary>
     /// Gets the set of root paths for all music libraries.
     /// </summary>
     [JsonInclude]
-    public HashSet<string> MusicRootPaths => new(Music.SelectMany(l => l.RootPaths), StringComparer.OrdinalIgnoreCase);
+    public HashSet<string> MusicRootPaths => AggregateRootPaths(Music);
 
     /// <summary>
     /// Gets the set of root paths for all book libraries.
     /// </summary>
     [JsonInclude]
-    public HashSet<string> BookRootPaths => new(Books.SelectMany(l => l.RootPaths), StringComparer.OrdinalIgnoreCase);
+    public HashSet<string> BookRootPaths => AggregateRootPaths(Books);
 
     /// <summary>
     /// Gets the set of root paths for all other libraries.
     /// </summary>
     [JsonInclude]
-    public HashSet<string> OtherRootPaths => new(Other.SelectMany(l => l.RootPaths), StringComparer.OrdinalIgnoreCase);
+    public HashSet<string> OtherRootPaths => AggregateRootPaths(Other);
+
+    private static HashSet<string> AggregateRootPaths(IEnumerable<LibraryStatistics> libraries)
+    {
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var library in libraries)
+        {
+            foreach (var path in library.RootPaths)
+            {
+                result.Add(path);
+            }
+        }
+
+        return result;
+    }
 
     private static Dictionary<string, int> AggregateDictionaries(IEnumerable<Dictionary<string, int>> dictionaries)
     {

--- a/Jellyfin.Plugin.JellyfinHelper/Services/Statistics/MediaStatisticsService.cs
+++ b/Jellyfin.Plugin.JellyfinHelper/Services/Statistics/MediaStatisticsService.cs
@@ -414,6 +414,7 @@ public class MediaStatisticsService : IMediaStatisticsService
             var format = ext.TrimStart('.').ToUpperInvariant();
             stats.BookFormats[format] = stats.BookFormats.GetValueOrDefault(format) + 1;
             stats.BookFormatSizes[format] = stats.BookFormatSizes.GetValueOrDefault(format) + size;
+            FileSystemHelper.AddPath(stats.BookFormatPaths, format, file.FullName);
         }
         else
         {

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Jellyfin](https://jellyfin.org/) plugin that provides automated cleanup tasks
 
 [![Quality gate](https://img.shields.io/sonar/quality_gate/JellyPlugins_jellyfin-helper?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&logo=sonarcloud&logoColor=white&labelColor=2d333b)](https://sonarcloud.io/summary/new_code?id=JellyPlugins_jellyfin-helper)<br>
 [![codecov](https://img.shields.io/codecov/c/github/JellyPlugins/jellyfin-helper?style=flat-square&logo=codecov&logoColor=white&labelColor=2d333b)](https://codecov.io/gh/JellyPlugins/jellyfin-helper)<br>
-[![Tests](https://img.shields.io/badge/unit%20tests-5453-2ea043?style=flat-square&logo=checkmarx&logoColor=white&labelColor=2d333b)](Jellyfin.Plugin.JellyfinHelper.Tests/)<br>
+[![Tests](https://img.shields.io/badge/unit%20tests-5458-2ea043?style=flat-square&logo=checkmarx&logoColor=white&labelColor=2d333b)](Jellyfin.Plugin.JellyfinHelper.Tests/)<br>
 [![E2E](https://img.shields.io/badge/e2e%20tests-305-2ea043?style=flat-square&logo=docker&logoColor=white&labelColor=2d333b)](test/e2e/)
 
 </td>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A [Jellyfin](https://jellyfin.org/) plugin that provides automated cleanup tasks
 [![Quality gate](https://img.shields.io/sonar/quality_gate/JellyPlugins_jellyfin-helper?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&logo=sonarcloud&logoColor=white&labelColor=2d333b)](https://sonarcloud.io/summary/new_code?id=JellyPlugins_jellyfin-helper)<br>
 [![codecov](https://img.shields.io/codecov/c/github/JellyPlugins/jellyfin-helper?style=flat-square&logo=codecov&logoColor=white&labelColor=2d333b)](https://codecov.io/gh/JellyPlugins/jellyfin-helper)<br>
 [![Tests](https://img.shields.io/badge/unit%20tests-5458-2ea043?style=flat-square&logo=checkmarx&logoColor=white&labelColor=2d333b)](Jellyfin.Plugin.JellyfinHelper.Tests/)<br>
-[![E2E](https://img.shields.io/badge/e2e%20tests-305-2ea043?style=flat-square&logo=docker&logoColor=white&labelColor=2d333b)](test/e2e/)
+[![E2E](https://img.shields.io/badge/e2e%20tests-309-2ea043?style=flat-square&logo=docker&logoColor=white&labelColor=2d333b)](test/e2e/)
 
 </td>
 <td style="vertical-align: top; text-align: center;">

--- a/test/e2e/COVERAGE.md
+++ b/test/e2e/COVERAGE.md
@@ -246,11 +246,16 @@ plugin stays Active after every call).
   specs now **self-provision** their preconditions (configure Mock Radarr / set a
   non-Deactivate recs mode via API in `beforeAll`) instead of relying on leftover state,
   so they run rather than skip.
+- **Refresh resilience**: after repeated hard reloads the transient "Failed to load
+  statistics. Make sure you are an administrator." banner is **not stuck** (the loader
+  retries transient 401/403 auth-not-ready failures) and the overview repopulates.
 
 ## 10. UI: interactions
 | Covered | File |
 |---|---|
 | Codec breakdown row → file tree; folder expand/collapse; Expand/Collapse All; re-click closes | `trees.ui.spec.ts` |
+| Book-format breakdown row → file tree shows a **Books section with files** (not "No files found") | `trees.ui.spec.ts` |
+| Excluded Libraries multi-select **lists libraries** (not "No data") | `trees.ui.spec.ts` |
 | Health item → detail tree | `trees.ui.spec.ts` |
 | Logs arrive + **download file**; level filter → PUT /LogLevel **succeeds + persists DEBUG**; clear → DELETE **succeeds + empty state** | `logs.ui.spec.ts` |
 | **Unsaved dialog**: dirty band; appears on leaving dirty tab; absent after save; Discard drops edit | `unsaved-dialog.ui.spec.ts` |
@@ -331,11 +336,12 @@ Filesystem-verified via `docker exec` (skips loudly without Docker):
 - **Book library protection** (`books-protection.api.spec.ts`): a Book (eBook)
   library is TRACKED but NEVER deleted. Stats expose `Books` / `TotalBookFileCount`
   / `TotalBookFormats` with the KNOWN fixtures' `EPUB`+`PDF` keys (per-format counts
-  sum to the total); and with the most aggressive cleanup config (empty-folder +
-  all stages Activate, `UseTrash:false`, `OrphanMinAgeDays:0`) every `.epub`/`.pdf`
-  file and its folder survive on disk and no `.jellyfin-trash` is created: the
-  regression guard for the eBook-collection data-loss bug (books excluded by
-  collection type, never scanned by cleanup).
+  sum to the total), plus `BookRootPaths` and per-library `BookFormatPaths` so the
+  codec-tab book drill-down can list files; and with the most aggressive cleanup
+  config (empty-folder + all stages Activate, `UseTrash:false`, `OrphanMinAgeDays:0`)
+  every `.epub`/`.pdf` file and its folder survive on disk and no `.jellyfin-trash`
+  is created: the regression guard for the eBook-collection data-loss bug (books
+  excluded by collection type, never scanned by cleanup).
 - **Growth timeline** (`growth-timeline-fs.api.spec.ts`): the cumulative series is
   non-empty and monotonically non-decreasing, latest totals are positive/coherent
   (bytes > 0, files > 0), directories-scanned positive, no future-dated point.

--- a/test/e2e/tests/books-protection.api.spec.ts
+++ b/test/e2e/tests/books-protection.api.spec.ts
@@ -114,10 +114,10 @@ test.describe('Book libraries are tracked in statistics but never deleted by cle
     // present. This asserts the server now emits the field with the fixture root.
     const stats = await getStats();
 
-    if (stats.Books.length === 0) {
-      test.skip(true, 'no Book library present in fixture (BookRootPaths contract verified vacuously)');
-      return;
-    }
+    // The e2e fixture always provisions a Books library (global-setup ensures
+    // /media/Books with EPUB+PDF), so this must be present - do not skip, or the
+    // BookRootPaths contract would pass vacuously.
+    expect(stats.Books.length, 'Books fixture must be provisioned by global-setup').toBeGreaterThan(0);
 
     expect(Array.isArray(stats.BookRootPaths), 'BookRootPaths is present as an array').toBe(true);
     expect(stats.BookRootPaths.length, 'BookRootPaths is non-empty when a Book library exists').toBeGreaterThan(0);

--- a/test/e2e/tests/books-protection.api.spec.ts
+++ b/test/e2e/tests/books-protection.api.spec.ts
@@ -16,6 +16,7 @@ interface Stats {
   TotalBookFileCount: number;
   TotalBookSize: number;
   TotalBookFormats: Record<string, number>;
+  BookRootPaths: string[];
 }
 
 let ctx: APIRequestContext;
@@ -103,6 +104,25 @@ test.describe('Book libraries are tracked in statistics but never deleted by cle
     for (const lib of stats.Books) {
       expect(lib.BookFileCount ?? 0, `Books entry ${lib.LibraryName} has files`).toBeGreaterThan(0);
     }
+  });
+
+  test('ROOT PATHS: BookRootPaths is emitted so the codec drill-down can group book files by library root', async () => {
+    // The Codec tab's book-format drill-down (renderFileTree in the UI) needs a
+    // BookRootPaths set to trim a common prefix, exactly like MovieRootPaths /
+    // TvShowRootPaths do. Before this field existed the book file tree fell back to
+    // an empty totals branch and rendered "No files found" even though books were
+    // present. This asserts the server now emits the field with the fixture root.
+    const stats = await getStats();
+
+    if (stats.Books.length === 0) {
+      test.skip(true, 'no Book library present in fixture (BookRootPaths contract verified vacuously)');
+      return;
+    }
+
+    expect(Array.isArray(stats.BookRootPaths), 'BookRootPaths is present as an array').toBe(true);
+    expect(stats.BookRootPaths.length, 'BookRootPaths is non-empty when a Book library exists').toBeGreaterThan(0);
+    // The fixture provisions the Books library at /media/Books.
+    expect(stats.BookRootPaths.some((r) => r.includes('Books')), 'BookRootPaths contains the book library root').toBe(true);
   });
 
   test('NO-DELETE: aggressive Activate-mode cleanup leaves every eBook file/folder intact', async () => {

--- a/test/e2e/tests/tabs.ui.spec.ts
+++ b/test/e2e/tests/tabs.ui.spec.ts
@@ -29,3 +29,26 @@ test('overview renders stat cards after scan', async ({ page }) => {
     page.locator('#overviewContent .stat-card, #overviewContent .library-table').first(),
   ).toBeVisible({ timeout: 20_000 });
 });
+
+test('a browser refresh does not leave the stats admin-error banner stuck', async ({ page }) => {
+  // On refresh the stats request can fire before Jellyfin's ApiClient token is
+  // ready, briefly yielding 401/403. The plugin retries transient auth failures,
+  // so an admin must never be left looking at "Failed to load statistics. Make
+  // sure you are an administrator." Reload a few times and assert the banner is
+  // not stuck and the overview still populates.
+  await openDashboard(page);
+
+  const errBanner = page.locator('#overviewContent .error-msg', { hasText: /administrator/i });
+
+  for (let i = 0; i < 3; i++) {
+    await page.reload({ waitUntil: 'load' });
+    await expect(page.locator('.tab-bar')).toBeVisible({ timeout: 15_000 });
+    // Once loading settles the transient banner must be gone (retry resolves it).
+    await expect(errBanner).toBeHidden({ timeout: 20_000 });
+  }
+
+  // The overview must ultimately show real content, proving stats loaded.
+  await expect(
+    page.locator('#overviewContent .stat-card, #overviewContent .library-table').first(),
+  ).toBeVisible({ timeout: 20_000 });
+});

--- a/test/e2e/tests/tabs.ui.spec.ts
+++ b/test/e2e/tests/tabs.ui.spec.ts
@@ -30,24 +30,32 @@ test('overview renders stat cards after scan', async ({ page }) => {
   ).toBeVisible({ timeout: 20_000 });
 });
 
-test('a browser refresh does not leave the stats admin-error banner stuck', async ({ page }) => {
-  // On refresh the stats request can fire before Jellyfin's ApiClient token is
-  // ready, briefly yielding 401/403. The plugin retries transient auth failures,
-  // so an admin must never be left looking at "Failed to load statistics. Make
-  // sure you are an administrator." Reload a few times and assert the banner is
-  // not stuck and the overview still populates.
+test('a transient auth failure on refresh is retried, not shown as a stuck admin error', async ({ page }) => {
+  // Regression guard for the refresh race: on reload the stats read can fire before
+  // Jellyfin's ApiClient token is ready and come back 401/403. The plugin must retry
+  // the idempotent Latest read instead of leaving the admin an error banner. We force
+  // the failure deterministically: the first two MediaStatistics/Latest requests are
+  // answered 403, the rest pass through. Without the retry this leaves the banner
+  // stuck; with it, the banner clears and the overview populates.
+  let latestHits = 0;
+  await page.route('**/JellyfinHelper/MediaStatistics/Latest', async (route) => {
+    latestHits += 1;
+    if (latestHits <= 2) {
+      await route.fulfill({ status: 403, contentType: 'application/json', body: '{}' });
+      return;
+    }
+    await route.continue();
+  });
+
   await openDashboard(page);
 
   const errBanner = page.locator('#overviewContent .error-msg', { hasText: /administrator/i });
 
-  for (let i = 0; i < 3; i++) {
-    await page.reload({ waitUntil: 'load' });
-    await expect(page.locator('.tab-bar')).toBeVisible({ timeout: 15_000 });
-    // Once loading settles the transient banner must be gone (retry resolves it).
-    await expect(errBanner).toBeHidden({ timeout: 20_000 });
-  }
-
-  // The overview must ultimately show real content, proving stats loaded.
+  // The forced 403s must have been consumed (proves the retry actually re-requested).
+  await expect.poll(() => latestHits, { timeout: 20_000 }).toBeGreaterThan(2);
+  // After the retries resolve, no stuck admin-error banner.
+  await expect(errBanner).toBeHidden({ timeout: 20_000 });
+  // And the overview ultimately shows real content, proving stats loaded post-retry.
   await expect(
     page.locator('#overviewContent .stat-card, #overviewContent .library-table').first(),
   ).toBeVisible({ timeout: 20_000 });

--- a/test/e2e/tests/trees.ui.spec.ts
+++ b/test/e2e/tests/trees.ui.spec.ts
@@ -77,7 +77,16 @@ test('Codecs tab: clicking a book format shows the book file tree, not an empty 
   // The books section must render (badge-books) and must NOT be the empty state.
   await expect(panel.locator('.file-tree-section .badge-books')).toBeVisible();
   await expect(panel.locator('.file-tree-empty')).toHaveCount(0);
-  await expect(panel.locator('.tree-leaf, .tree-leaf-file-name').first()).toBeVisible();
+  // Book file paths are present in the tree (this is what BookFormatPaths feeds).
+  // They live inside collapsed folder nodes, so assert at least one exists, then
+  // expand the tree to prove a real leaf becomes visible - mirroring the codec test.
+  const leaves = panel.locator('.tree-leaf, .tree-leaf-file-name');
+  expect(await leaves.count(), 'book file leaves must be rendered').toBeGreaterThan(0);
+  const expandAll = panel.locator('[data-tree-action="expand"]');
+  if (await expandAll.count()) {
+    await expandAll.click();
+    await expect(leaves.first()).toBeVisible();
+  }
 });
 
 test('Settings tab: the Excluded Libraries multi-select lists libraries', async ({ page }) => {

--- a/test/e2e/tests/trees.ui.spec.ts
+++ b/test/e2e/tests/trees.ui.spec.ts
@@ -55,3 +55,47 @@ test('Health tab: clicking a health item opens its detail tree', async ({ page }
   const panel = page.locator('#healthDetailPanel');
   await expect(panel).toHaveClass(/file-tree-panel-visible/);
 });
+
+test('Codecs tab: clicking a book format shows the book file tree, not an empty state', async ({ page }) => {
+  // Regression guard for the book-format drill-down: under Jellyfin 12 the file
+  // tree renderer had no "books" section and excluded books from its file total,
+  // so clicking a book format (CBZ/EPUB/PDF) rendered "No files found." even
+  // though the chart above listed those formats. This clicks the bookFormats row
+  // and asserts a real books section with at least one file node appears.
+  await openDashboard(page);
+  await switchTab(page, 'codecs');
+
+  const bookRow = page.locator('.codec-row.codec-clickable[data-chart="bookFormats"]').first();
+  // The bookFormats chart only renders when a Book library exists in the fixture.
+  if ((await bookRow.count()) === 0) {
+    test.skip(true, 'no book-format breakdown present in this fixture');
+    return;
+  }
+  await expect(bookRow).toBeVisible({ timeout: 20_000 });
+  await bookRow.click();
+
+  const panel = page.locator('#codecDetail_bookFormats');
+  await expect(panel).toHaveClass(/file-tree-panel-visible/);
+  // The books section must render (badge-books) and must NOT be the empty state.
+  await expect(panel.locator('.file-tree-section .badge-books')).toBeVisible();
+  await expect(panel.locator('.file-tree-empty')).toHaveCount(0);
+  await expect(panel.locator('.tree-leaf, .tree-leaf-file-name').first()).toBeVisible();
+});
+
+test('Settings tab: the Excluded Libraries multi-select lists libraries', async ({ page }) => {
+  // Regression guard for the empty "Excluded Libraries" dropdown: the frontend
+  // read data.libraries (camelCase) but Jellyfin 12 serializes the response as
+  // data.Libraries (PascalCase), so the list came back empty and the panel showed
+  // "No data". This asserts the multi-select is populated with real entries.
+  await openDashboard(page);
+  await switchTab(page, 'settings');
+
+  const wrapper = page.locator('#cfgExcludedWrapper');
+  await expect(wrapper.locator('.library-multiselect-toggle')).toBeVisible({ timeout: 20_000 });
+
+  // Open the dropdown panel and assert it contains selectable library entries
+  // rather than the "No data" fallback.
+  await wrapper.locator('.library-multiselect-toggle').click();
+  await expect(wrapper.locator('.library-multiselect-item').first()).toBeVisible();
+  expect(await wrapper.locator('.library-multiselect-item').count()).toBeGreaterThan(0);
+});

--- a/test/e2e/tests/trees.ui.spec.ts
+++ b/test/e2e/tests/trees.ui.spec.ts
@@ -65,13 +65,11 @@ test('Codecs tab: clicking a book format shows the book file tree, not an empty 
   await openDashboard(page);
   await switchTab(page, 'codecs');
 
+  // The e2e fixture always provisions a Books library (EPUB+PDF), so the
+  // bookFormats breakdown must render. Do not skip on absence, or this regression
+  // guard would pass without ever exercising the book file-tree path.
   const bookRow = page.locator('.codec-row.codec-clickable[data-chart="bookFormats"]').first();
-  // The bookFormats chart only renders when a Book library exists in the fixture.
-  if ((await bookRow.count()) === 0) {
-    test.skip(true, 'no book-format breakdown present in this fixture');
-    return;
-  }
-  await expect(bookRow).toBeVisible({ timeout: 20_000 });
+  await expect(bookRow, 'bookFormats breakdown row must render from the Books fixture').toBeVisible({ timeout: 20_000 });
   await bookRow.click();
 
   const panel = page.locator('#codecDetail_bookFormats');

--- a/test/e2e/tests/trends-chart.ui.spec.ts
+++ b/test/e2e/tests/trends-chart.ui.spec.ts
@@ -135,9 +135,12 @@ test.describe('trend chart touch gestures', () => {
 
     // A single-finger touchStart+touchEnd at the same point is a tap. Dispatched via CDP for a
     // deterministic touch sequence (the same mechanism the pinch test uses).
+    // The touchEnd MUST carry the released point so the browser populates
+    // event.changedTouches with a single entry - the chart's tap handler bails when
+    // changedTouches.length !== 1, and an empty touchPoints made this flaky.
     const client = await page.context().newCDPSession(page);
     await client.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ x: cx, y: cy }] });
-    await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+    await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [{ x: cx, y: cy }] });
 
     // Synchronize on the observable outcome (tooltip becomes visible), not a fixed wait.
     await expect(page.locator('.trend-tooltip')).toHaveClass(/visible/, { timeout: 5_000 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Books support to media statistics, codec drill-downs, and file-tree displays.
  - Book library root paths, format-specific files, and file counts are now included.
  - Book libraries appear in a dedicated section of media path views.

- **Bug Fixes**
  - Improved settings compatibility with API responses using different field-name casing.
  - Library names, library types, trash deletion results, and Seerr connection tests now display more reliably.
  - Statistics loading now recovers from temporary authentication or network issues during page refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->